### PR TITLE
feat(api): configure docker s3 container and add to start scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,21 @@ install:
 
 - nodejs, latest
 - yarn, latest
+- docker and docker compose, latest
+
+## installing docker
+
+### Windows/MacOS
+
+For these platforms, you should just need to install docker desktop - this should include docker compose
+
+### Linux
+
+For Linux, you'll need to install docker and docker compose separately. Beware that on Ubuntu at least, the
+default docker apt package is *not* what you want; use docker.io with apt instead (`sudo apt-get install docker.io`).
+See https://docs.docker.com/compose/install/ and https://docs.docker.com/install/linux/linux-postinstall/ for
+instructions on installing docker compose and setting docker to be runnable without root (highly recommended
+for the sake of our build tools).
 
 ## getting started
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,3 +15,4 @@ services:
 
 volumes: 
   s3-data:
+    

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,17 @@
+version: '3.7'
+
+services: 
+  beautiful-portland-s3:
+    container_name: beautiful-portland-s3
+    image: minio/minio
+    restart: unless-stopped
+    ports: 
+      - "9095:9000"
+    stop_signal: SIGINT
+    environment: 
+      - MINIO_ACCESS_KEY=b@dpass
+      - MINIO_SECRET_KEY=r3alb@dpass
+    command: server /s3-data
+
+volumes: 
+  s3-data:

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -6,7 +6,12 @@
   "license": "MIT",
   "scripts": {
     "bootstrap": "cd ../../ ; yarn bootstrap",
-    "start": "node server.js"
+    "node:start": "node server.js",
+    "s3:container:kill": "docker-compose rm --stop --force beautiful-portland-s3",
+    "s3:container:start": "docker-compose up -d beautiful-portland-s3",
+    "s3:start": "run-s s3:container:kill s3:container:start",
+    "services:start": "run-s s3:start",
+    "start": "run-p services:start node:start"
   },
   "dependencies": {
     "express": "^4.16.4",


### PR DESCRIPTION
Closes issue #15 

Add a docker container with a minio image that can act as our dev build s3 container. Add docker-compose.yaml file for configuring this container and yarn scripts for killing and starting it. Configuration includes docker volume for persistent storage of test data.