### PR TITLE
feat(build): add build directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 yarn-error.log
 lerna-debug.log
 npm-debug.log
+packages/ui/build/


### PR DESCRIPTION
The build directory holds source code compiled via create-react-app and webpack for deployment. There's no reason for these files to be in the repo.