### PR TITLE
feat(build): add master/helper scripts to deploy app on server

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "build:api": "cd packages/api && yarn build",
     "clean": "run-p clean:api",
     "clean:api": "cd packages/api && yarn clean",
+    "deploy": "run-p start:api deploy:ui",
+    "deploy:ui": "cd packages/ui && yarn deploy",
     "start": "run-p start:ui start:api",
     "start:api": "cd packages/api && yarn start",
     "start:ui": "cd packages/ui && yarn start",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -9,8 +9,10 @@
     "bootstrap": "cd ../../ ; yarn bootstrap",
     "start": "react-scripts start",
     "build": "react-scripts build",
+    "deploy": "run-s build serve",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "serve": "serve -s build -l 4000"
   },
   "dependencies": {
     "axios": "^0.18.0",


### PR DESCRIPTION
Description: attempting to make use of the CRA recommended static deployment server for the frontend. New script + helpers launches api server, builds ui project using CRA scripts, and deploys compiled code using serve.

Note: this still doesn't seem to be getting us what we want, as the compiled code seems to have javascript errors, but it's possible that this is a source code issue and not a deploy issue. Pushing this so it will get to our test server, which will also have the side effect with the current pipeline of pushing the compiled UI to the static s3 server, we can see then if it has the same issue.