### PR TITLE
fix(build): remove unused deploy scripts and hardcoded auth endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,6 @@
     "build:api": "cd packages/api && yarn build",
     "clean": "run-p clean:api",
     "clean:api": "cd packages/api && yarn clean",
-    "deploy": "run-p start:api deploy:ui",
-    "deploy:ui": "cd packages/ui && yarn deploy",
     "start": "run-p start:ui start:api",
     "start:api": "cd packages/api && yarn start",
     "start:ui": "cd packages/ui && yarn start",

--- a/packages/api/config/auth.json
+++ b/packages/api/config/auth.json
@@ -2,7 +2,7 @@
     "google": {
         "clientID": "889266104593-7bp3o9mj4aqmlloa565iu80gliqm6ee3.apps.googleusercontent.com",
         "clientSecret": "QthIhx2SQaCJSqfVjX6jLI7P",
-        "callbackURL": "http://localhost:5000/auth/google/callback"
+        "callbackURL": "/auth/google/callback"
     },
     "adminAccount":"gold.team.pdx@gmail.com"
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -9,10 +9,8 @@
     "bootstrap": "cd ../../ ; yarn bootstrap",
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "deploy": "run-s build serve",
     "test": "react-scripts test",
-    "eject": "react-scripts eject",
-    "serve": "serve -s build -l 4000"
+    "eject": "react-scripts eject"
   },
   "dependencies": {
     "axios": "^0.18.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "scripts": {
     "bootstrap": "cd ../../ ; yarn bootstrap",
-    "start": "react-scripts start",
+    "start": "REACT_APP_API_ENDPOINT=http://localhost:5000 react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"

--- a/packages/ui/src/Components/Dashboard/Login.js
+++ b/packages/ui/src/Components/Dashboard/Login.js
@@ -6,7 +6,7 @@ export default class Login extends Component {
 		return (
 			<div style={{position:"absolute",top:"50%",left:"40%"}}>
 				<Container>
-					<a href="http://localhost:5000/auth/google" style={{color:"white"}}>
+					<a href="/auth/google" style={{color:"white"}}>
 						<Button size='massive' color='google plus'><Icon name='google' />Admin Login</Button>
 					</a>
 				</Container>

--- a/packages/ui/src/Components/Dashboard/Login.js
+++ b/packages/ui/src/Components/Dashboard/Login.js
@@ -1,12 +1,14 @@
 import React, { Component } from 'react'
 import { Container, Button, Icon } from 'semantic-ui-react'
+require ('dotenv').config()
 
 export default class Login extends Component {
   render() {
+	  	let callbackHost = process.env.REACT_APP_API_ENDPOINT || ''
 		return (
 			<div style={{position:"absolute",top:"50%",left:"40%"}}>
 				<Container>
-					<a href="/auth/google" style={{color:"white"}}>
+					<a href={`${callbackHost}/auth/google`} style={{color:"white"}}>
 						<Button size='massive' color='google plus'><Icon name='google' />Admin Login</Button>
 					</a>
 				</Container>


### PR DESCRIPTION
Description: the yarn scripts for deployment that I added yesterday proved unnecessary to the deployment solution that ended up working. Also, some of the endpoints for Google auth were hardcoded to localhost, we can simply remove the hostname from these as that will be caught by the proxy in development and by nginx routing in the deployed environments.