### PR TITLE
Updated volunteerform validation

### DIFF
--- a/packages/api/visitor.js
+++ b/packages/api/visitor.js
@@ -51,13 +51,14 @@ volunteerFormGetEventInfo = function(req, res) {
                 max_signups: category.max_signups,
                 real_signups: 0,
                 min_servings: category.min_servings,
+                min_vegan_servings: Math.ceil(Math.floor(category.min_servings/3) / 10) * 10,
                 food: category.food,
                 min_vegan: category.min_vegan,
                 real_vegan: 0, 
                 servings: 0
             })
             category.submissions.forEach(sub => {
-                response_data[i].signups++
+                response_data[i].real_signups++
                 if(response_data[i].food && sub.vegan) {
                     response_data[i].real_vegan++
                 }

--- a/packages/ui/src/Components/Volunteer/Item.js
+++ b/packages/ui/src/Components/Volunteer/Item.js
@@ -94,7 +94,7 @@ export default class Item extends Component {
 	onCategoryChange = (event, data) => {
 		this.clearForm()
 		let temp = data.options.find((elem) => { return elem.key === data.value})
-		this.validateField(data.name, data.value)
+		this.validateField('type', data.value)
 		this.setState({type: data.value, cat_info: temp.data}, this.validateForm)
 	}
 
@@ -161,7 +161,7 @@ export default class Item extends Component {
 										this.state.volunteer_emailValid &&
 										this.state.descriptionValid
 
-		if(this.state.cat_info.food && this.state.cat_info.real_signups >= this.state.cat_info.max_signups) {
+		if(this.state.cat_info.real_signups >= this.state.cat_info.max_signups) {
 			this.setState({
 				formValid,
 				message: 'Sorry, but this course is full up on signups. Please consider volunteering for another category!\n',
@@ -332,9 +332,7 @@ export default class Item extends Component {
 								<span>{this.state.errors.volunteer_phone || ' ✓'}</span>
 							</div>
 						</Form.Group>
-						{/* {console.log(!this.state.formValid)}
-						{console.log(disableSubmit)}
-						{console.log(this.state.disableAll)} */}
+
 						<Button color="green" disabled={!this.state.formValid || disableSubmit || this.state.disableAll}>
 							Submit
 						</Button>

--- a/packages/ui/src/Components/Volunteer/Item.js
+++ b/packages/ui/src/Components/Volunteer/Item.js
@@ -1,15 +1,18 @@
 import React, { Component } from 'react'
-import { Form, Button, Dropdown, Segment } from 'semantic-ui-react'
+import { Header, Form, Button, Dropdown, Segment } from 'semantic-ui-react'
 import '../Stylesheets/Item.css'
 
 export default class Item extends Component {
 	constructor(props) {
 		super(props)
 		this.onChange = this.onChange.bind(this)
+		this.onCategoryChange = this.onCategoryChange.bind(this)
 		this.onSubmit = this.onSubmit.bind(this)
 		this.validateField = this.validateField.bind(this)
 		this.errorClass = this.errorClass.bind(this)
+
 		this.state = {
+			cat_info: {},
 			description: '',
 			type: '',
 			servings: 0,
@@ -27,6 +30,9 @@ export default class Item extends Component {
 				volunteer_phone: '',
 				volunteer_email: ''
 			},
+			messageNeeded: false,
+			message: '',
+			disableAll: false,
 			typeValid: false,
 			descriptionValid: false,
 			servingsValid: false,
@@ -56,6 +62,9 @@ export default class Item extends Component {
 				volunteer_phone: '',
 				volunteer_email: ''
 			},
+			messageNeeded: false,
+			message: '',
+			disableAll: false,
 			typeValid: false,
 			descriptionValid: false,
 			servingsValid: false,
@@ -73,13 +82,20 @@ export default class Item extends Component {
 	}
 
 	updateCheckbox = (event, data) => {
-		this.setState({ [data.name]: data.checked })
+		this.setState({ [data.name]: data.checked }, this.validateForm)
 	}
 
 	onChange = (event, data) => {
 		this.setState({ [data.name]: data.value }, () => {
 			this.validateField(data.name, data.value)
 		})
+	}
+
+	onCategoryChange = (event, data) => {
+		this.clearForm()
+		let temp = data.options.find((elem) => { return elem.key === data.value})
+		this.validateField(data.name, data.value)
+		this.setState({type: data.value, cat_info: temp.data}, this.validateForm)
 	}
 
 	validateField(fieldName, value) {
@@ -91,6 +107,8 @@ export default class Item extends Component {
 		let volunteer_emailValid = this.state.volunteer_emailValid
 		let descriptionValid = this.state.descriptionValid
 
+		let min_servings = this.state.vegan ? this.state.cat_info.min_vegan_servings : this.state.cat_info.min_servings
+
 		switch (fieldName) {
 			case 'type':
 				typeValid = value
@@ -101,8 +119,8 @@ export default class Item extends Component {
 				errors.description = descriptionValid ? '' : ' ✗ Message must be longer than five characters.'
 				break
 			case 'servings':
-				servingsValid = value > 0 && value <= this.props.max_servings
-				errors.servings = servingsValid ? '' : ' ✗ Please enter a vaild number between 0~' + this.props.max_servings + '.'
+				servingsValid = value >= min_servings && value <= this.props.max_servings
+				errors.servings = servingsValid ? '' : ' ✗ Please enter a vaild number between ' + min_servings + '~' + this.props.max_servings + '.'
 				break
 			case 'volunteer_name':
 				volunteer_nameValid = value.length > 2
@@ -135,15 +153,33 @@ export default class Item extends Component {
 	}
 
 	validateForm() {
-		this.setState({
-			formValid:
-				this.state.typeValid &&
-				this.state.servingsValid &&
-				this.state.volunteer_nameValid &&
-				this.state.volunteer_phoneValid &&
-				this.state.volunteer_emailValid &&
-				this.state.descriptionValid
-		})
+		let numVeganNeeded = this.state.cat_info.food ? this.state.cat_info.min_vegan - this.state.cat_info.real_vegan : 0
+		let formValid = this.state.typeValid &&
+										this.state.servingsValid &&
+										this.state.volunteer_nameValid &&
+										this.state.volunteer_phoneValid &&
+										this.state.volunteer_emailValid &&
+										this.state.descriptionValid
+
+		if(this.state.cat_info.food && this.state.cat_info.real_signups >= this.state.cat_info.max_signups) {
+			this.setState({
+				formValid,
+				message: 'Sorry, but this course is full up on signups. Please consider volunteering for another category!\n',
+				messageNeeded: true,
+				disableAll: true
+			})
+		} else if(this.state.cat_info.food && this.state.cat_info.real_signups + numVeganNeeded === this.state.cat_info.max_signups && !this.state.vegan) {
+			this.setState({
+				formValid,
+				message: 'Signups for this category are limited to Vegan options only.\n',
+				messageNeeded: true
+			})
+		} else {
+			this.setState({
+				formValid,
+				messageNeeded:false
+			})
+		}
 	}
 
 	errorClass(error) {
@@ -151,21 +187,23 @@ export default class Item extends Component {
 	}
 
 	render() {
-    let options = []
-		this.props.event_info.forEach(category => {
-			options.push({
+		let options = this.props.event_info.map(category => {
+			return {
 				key: category.type,
 				text: category.type,
 				value: category.type,
-				servings: category.servings
-			})
+				data: category
+			}
 		})
-		let curType = options.find((elem) => {return elem.key === this.state.type})
-		let isDisabled = curType ? curType.servings >= this.props.max_servings : false
-		
+
+		let disableSubmit = this.state.messageNeeded
+
 		return (
 
 			<div>
+				{this.state.messageNeeded && 
+					<Header as="h3">{this.state.message}</Header>
+				}
 				<Segment>
 					<Form onSubmit={this.onSubmit}>
 						<br />
@@ -177,7 +215,7 @@ export default class Item extends Component {
 									<Dropdown
 										name="type"
 										value={this.state.type}
-										onChange={this.onChange}
+										onChange={this.onCategoryChange}
 										placeholder="type"
 										fluid
 										selection
@@ -202,7 +240,7 @@ export default class Item extends Component {
 									style={{ width: '370px' }}
 									label="Item"
 									placeholder="description"
-									disabled={isDisabled}
+									disabled={this.state.disableAll}
 								/>
 								<div>
 									<span>{this.state.errors.description || ' ✓'}</span>
@@ -210,30 +248,34 @@ export default class Item extends Component {
 							</Form.Group>
 						</div>
 						<br />
-						<Form.Group>
-							<Form.Checkbox
-								onChange={this.updateCheckbox}
-								checked={this.state.vegan}
-								name="vegan"
-								label="Vegan"
-								disabled={isDisabled}
-							/>
-							<Form.Checkbox
-								onChange={this.updateCheckbox}
-								checked={this.state.vegetarian}
-								name="vegetarian"
-								label="Vegetarian"
-								disabled={isDisabled}
-							/>
-							<Form.Checkbox
-								onChange={this.updateCheckbox}
-								checked={this.state.gluten_free}
-								name="gluten_free"
-								label="Gluten-free"
-								disabled={isDisabled}
-							/>
-						</Form.Group>
-						<br />
+						{this.state.cat_info.food && 
+							<div>
+								<Form.Group>
+									<Form.Checkbox
+										onChange={this.updateCheckbox}
+										checked={this.state.vegan}
+										name="vegan"
+										label="Vegan"
+										disabled={this.state.disableAll}
+									/>
+									<Form.Checkbox
+										onChange={this.updateCheckbox}
+										checked={this.state.vegetarian}
+										name="vegetarian"
+										label="Vegetarian"
+										disabled={this.state.disableAll}
+									/>
+									<Form.Checkbox
+										onChange={this.updateCheckbox}
+										checked={this.state.gluten_free}
+										name="gluten_free"
+										label="Gluten-free"
+										disabled={this.state.disableAll}
+									/>
+								</Form.Group>
+								<br />
+							</div>
+						}
 
 						<Form.Group inline>
 							<div className={`input-wrapper ${this.errorClass(this.state.errors.servings)}`}>
@@ -244,7 +286,7 @@ export default class Item extends Component {
 										onChange={this.onChange}
 										inline
 										label="Servings"
-										disabled={isDisabled}
+										disabled={this.state.isDisabled}
 									/>
 									<div>
 										<span>{this.state.errors.servings || ' ✓'}</span>
@@ -261,7 +303,7 @@ export default class Item extends Component {
 									onChange={this.onChange}
 									label="Name"
 									placeholder=" John"
-									disabled={isDisabled}
+									disabled={this.state.isDisabled}
 								/>
 								<span>{this.state.errors.volunteer_name || ' ✓'}</span>
 							</div>
@@ -273,7 +315,7 @@ export default class Item extends Component {
 									onChange={this.onChange}
 									label="Email"
 									placeholder=" xxxx@gmail.com"
-									disabled={isDisabled}
+									disabled={this.state.isDisabled}
 								/>
 								<span>{this.state.errors.volunteer_email || ' ✓'}</span>
 							</div>
@@ -285,12 +327,15 @@ export default class Item extends Component {
 									onChange={this.onChange}
 									label="Phone"
 									placeholder=" xxx-xxx-xxxx"
-									disabled={isDisabled}
+									disabled={this.state.isDisabled}
 								/>
 								<span>{this.state.errors.volunteer_phone || ' ✓'}</span>
 							</div>
 						</Form.Group>
-						<Button color="green" disabled={!this.state.formValid || isDisabled}>
+						{/* {console.log(!this.state.formValid)}
+						{console.log(disableSubmit)}
+						{console.log(this.state.disableAll)} */}
+						<Button color="green" disabled={!this.state.formValid || disableSubmit || this.state.disableAll}>
 							Submit
 						</Button>
 					</Form>

--- a/packages/ui/src/Components/Volunteer/Item.js
+++ b/packages/ui/src/Components/Volunteer/Item.js
@@ -286,7 +286,7 @@ export default class Item extends Component {
 										onChange={this.onChange}
 										inline
 										label="Servings"
-										disabled={this.state.isDisabled}
+										disabled={this.state.disableAll}
 									/>
 									<div>
 										<span>{this.state.errors.servings || ' ✓'}</span>
@@ -303,7 +303,7 @@ export default class Item extends Component {
 									onChange={this.onChange}
 									label="Name"
 									placeholder=" John"
-									disabled={this.state.isDisabled}
+									disabled={this.state.disableAll}
 								/>
 								<span>{this.state.errors.volunteer_name || ' ✓'}</span>
 							</div>
@@ -315,7 +315,7 @@ export default class Item extends Component {
 									onChange={this.onChange}
 									label="Email"
 									placeholder=" xxxx@gmail.com"
-									disabled={this.state.isDisabled}
+									disabled={this.state.disableAll}
 								/>
 								<span>{this.state.errors.volunteer_email || ' ✓'}</span>
 							</div>
@@ -327,7 +327,7 @@ export default class Item extends Component {
 									onChange={this.onChange}
 									label="Phone"
 									placeholder=" xxx-xxx-xxxx"
-									disabled={this.state.isDisabled}
+									disabled={this.state.disableAll}
 								/>
 								<span>{this.state.errors.volunteer_phone || ' ✓'}</span>
 							</div>

--- a/packages/ui/src/Components/Volunteer/VolunteerForm.js
+++ b/packages/ui/src/Components/Volunteer/VolunteerForm.js
@@ -16,6 +16,9 @@ export default class VolunteerForm extends Component {
     }
     this.state = {
       date: params.get("date"),
+      coordinator: '',
+      coordinator_phone: '',
+      location: '',
       event_info: [{type: "n/a", servings: 0}],
       max_servings: 0
     }

--- a/packages/ui/src/Components/Volunteer/VolunteerForm.js
+++ b/packages/ui/src/Components/Volunteer/VolunteerForm.js
@@ -33,10 +33,7 @@ export default class VolunteerForm extends Component {
       .catch(err => {
         console.log(err, "Try again.")
       })
-    this.setState((prevState) => {
-      prevState.event_info.find((elem) => {return elem.type === data.type}).servings += data.servings
-      return prevState
-    })
+    window.location.reload()
   }
 
   async componentDidMount() {


### PR DESCRIPTION
Added in the new validation logic for max_signups and min_servings. If signups are full, a message currently displays and disables all input fields. If the # of open signups left equal the minimum # of vegan signups for that category, it will only allow vegan submissions and display a message indicating as such. Minimum servings are also adjusted on the fly for vegan submissions. 

I've also added validation to ensure the date getting used follows our established format. If the date given in the URL isn't valid, or our DB doesn't find an event with a given date, it currently redirects to the home page.

I also removed the code for Context and EventList, as that will live entirely in the dashboard now.