### PR TITLE
Refactor dashboard routing, decouple DashMenu

### DIFF
--- a/packages/ui/src/App.js
+++ b/packages/ui/src/App.js
@@ -1,14 +1,14 @@
-import React, { Component } from "react"
-import { BrowserRouter as Router, Route, Switch } from "react-router-dom"
-import MyProvider from "./Components/Context/MyProvider"
-import Home from "./Components/Home/Home"
-import About from "./Components/About/About"
-import VolunteerForm from "./Components/Volunteer/VolunteerForm"
-import Login from "./Components/Dashboard/Login"
-import AdminDashboard from "./Components/Dashboard/AdminDashboard"
-import ContactUs from "./Components/Contact/ContactUs.js"
-import NoMatch from "./Components/Error/NoMatch"
-import "./App.css"
+import React, { Component } from 'react'
+import { BrowserRouter as Router, Route, Switch } from 'react-router-dom'
+import MyProvider from './Components/Context/MyProvider'
+import Home from './Components/Home/Home'
+import About from './Components/About/About'
+import VolunteerForm from './Components/Volunteer/VolunteerForm'
+import Login from './Components/Dashboard/Login'
+import AdminDashboard from './Components/Dashboard/AdminDashboard'
+import ContactUs from './Components/Contact/ContactUs.js'
+import NoMatch from './Components/Error/NoMatch'
+import './App.css'
 
 class App extends Component {
   render() {

--- a/packages/ui/src/App.js
+++ b/packages/ui/src/App.js
@@ -1,33 +1,67 @@
-import React, { Component } from 'react'
-import { BrowserRouter as Router, Route, Switch } from 'react-router-dom'
-import MyProvider from './Components/Context/MyProvider'
-import Home from './Components/Home/Home'
-import About from './Components/About/About'
-import VolunteerForm from './Components/Volunteer/VolunteerForm'
-import Login from './Components/Dashboard/Login'
-import AdminDashboard from './Components/Dashboard/AdminDashboard'
-import ContactUs from './Components/Contact/ContactUs.js'
-import NoMatch from './Components/Error/NoMatch'
-import './App.css'
+import React, { Component } from "react"
+import { BrowserRouter as Router, Route, Switch } from "react-router-dom"
+import MyProvider from "./Components/Context/MyProvider"
+import Home from "./Components/Home/Home"
+import About from "./Components/About/About"
+import VolunteerForm from "./Components/Volunteer/VolunteerForm"
+import Login from "./Components/Dashboard/Login"
+import AdminDashboard from "./Components/Dashboard/AdminDashboard"
+import ContactUs from "./Components/Contact/ContactUs.js"
+import NoMatch from "./Components/Error/NoMatch"
+import "./App.css"
+import EditEventTemplate from "./Components/Dashboard/EventTemplate/EditEventTemplate"
+import AddEvent from "./Components/Dashboard/AddEvent"
+import UpcomingEvents from "./Components/Dashboard/UpcomingEvents"
+import VolunteerList from "./Components/Dashboard/VolunteerList"
+import EditCarouselImages from "./Components/Dashboard/Images/EditCarouselImages"
+import ViewAllImages from "./Components/Dashboard/Images/ViewAllImages"
+import NewStory from "./Components/Dashboard/Stories/NewStory"
+import ViewStories from "./Components/Dashboard/Stories/ViewStories"
 
 class App extends Component {
-	render() {
-		return (
-			<MyProvider>
-				<Router>
-					<Switch>
-						<Route exact path="/" component={Home} />
-						<Route path="/about" component={About} />
-						<Route path="/volunteer-form" component={VolunteerForm} />
-						<Route path="/login" component={Login} />
-						<Route path="/admin-dashboard" component={AdminDashboard} />
-						<Route path="/ContactUs" component={ContactUs} />
-						<Route component={NoMatch} />
-					</Switch>
-				</Router>
-			</MyProvider>
-		)
-	}
+  render() {
+    return (
+      <MyProvider>
+        <Router>
+          <Switch>
+            <Route exact path="/" component={Home} />
+            <Route path="/about" component={About} />
+            <Route path="/volunteer-form" component={VolunteerForm} />
+            <Route path="/login" component={Login} />
+            <Route exact path="/admin-dashboard" component={AdminDashboard} />
+            <Route
+              path="/admin-dashboard/EditEventTemplate"
+              component={EditEventTemplate}
+            />
+            <Route path="/admin-dashboard/AddEvent" component={AddEvent} />
+            <Route
+              path="/admin-dashboard/ViewUpcomingEvents"
+              component={UpcomingEvents}
+            />
+            <Route
+              path="/admin-dashboard/VolunteerList"
+              component={VolunteerList}
+            />
+            <Route
+              path="/admin-dashboard/EditImages"
+              component={EditCarouselImages}
+            />
+            <Route
+              path="/admin-dashboard/ViewImages"
+              component={ViewAllImages}
+            />
+            <Route path="/admin-dashboard/CreateStory" component={NewStory} />
+            <Route
+              path="/admin-dashboard/ViewStories"
+              component={ViewStories}
+            />
+            <Route path="/ContactUs" component={ContactUs} />
+            <Route component={NoMatch} />
+          </Switch>
+        </Router>
+      </MyProvider>
+    )
+  }
 }
 
 export default App

--- a/packages/ui/src/App.js
+++ b/packages/ui/src/App.js
@@ -9,14 +9,6 @@ import AdminDashboard from "./Components/Dashboard/AdminDashboard"
 import ContactUs from "./Components/Contact/ContactUs.js"
 import NoMatch from "./Components/Error/NoMatch"
 import "./App.css"
-import EditEventTemplate from "./Components/Dashboard/EventTemplate/EditEventTemplate"
-import AddEvent from "./Components/Dashboard/AddEvent"
-import UpcomingEvents from "./Components/Dashboard/UpcomingEvents"
-import VolunteerList from "./Components/Dashboard/VolunteerList"
-import EditCarouselImages from "./Components/Dashboard/Images/EditCarouselImages"
-import ViewAllImages from "./Components/Dashboard/Images/ViewAllImages"
-import NewStory from "./Components/Dashboard/Stories/NewStory"
-import ViewStories from "./Components/Dashboard/Stories/ViewStories"
 
 class App extends Component {
   render() {
@@ -28,33 +20,7 @@ class App extends Component {
             <Route path="/about" component={About} />
             <Route path="/volunteer-form" component={VolunteerForm} />
             <Route path="/login" component={Login} />
-            <Route exact path="/admin-dashboard" component={AdminDashboard} />
-            <Route
-              path="/admin-dashboard/EditEventTemplate"
-              component={EditEventTemplate}
-            />
-            <Route path="/admin-dashboard/AddEvent" component={AddEvent} />
-            <Route
-              path="/admin-dashboard/ViewUpcomingEvents"
-              component={UpcomingEvents}
-            />
-            <Route
-              path="/admin-dashboard/VolunteerList"
-              component={VolunteerList}
-            />
-            <Route
-              path="/admin-dashboard/EditImages"
-              component={EditCarouselImages}
-            />
-            <Route
-              path="/admin-dashboard/ViewImages"
-              component={ViewAllImages}
-            />
-            <Route path="/admin-dashboard/CreateStory" component={NewStory} />
-            <Route
-              path="/admin-dashboard/ViewStories"
-              component={ViewStories}
-            />
+            <Route path="/admin-dashboard" component={AdminDashboard} />
             <Route path="/ContactUs" component={ContactUs} />
             <Route component={NoMatch} />
           </Switch>

--- a/packages/ui/src/Components/Dashboard/AdminDashboard.js
+++ b/packages/ui/src/Components/Dashboard/AdminDashboard.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import { HashRouter, Route } from 'react-router-dom'
 import { Menu, Header, Segment, Button, Image } from 'semantic-ui-react'
 import Axios from 'axios'
 import WelcomeMessage from './WelcomeMessage'
@@ -6,6 +7,16 @@ import Moment from 'moment'
 import '../Stylesheets/AdminDashboard.css'
 import logo from '../../logoPhotos/bpdx_horizontallogo_white.png'
 import DashMenu from './DashMenu'
+import EditEventTemplate from './EventTemplate/EditEventTemplate';
+import AddEvent from './AddEvent'
+import UpcomingEvents from './UpcomingEvents'
+import VolunteerList from './VolunteerList'
+import EditCarouselImages from './Images/EditCarouselImages'
+import ViewAllImages from './Images/ViewAllImages'
+import NewStory from './Stories/NewStory'
+import ViewStories from './Stories/ViewStories'
+import EditEvent from './EditEvent'
+import EditStory from './Stories/EditStory'
 
 export default class AdminDashboard extends Component {
   state = {
@@ -48,11 +59,60 @@ export default class AdminDashboard extends Component {
     await console.log(this.state.editId)
   }
 
+  loginPrompt = () => {
+    return (
+      <Segment placeholder>
+        <Header as="h3" textAlign="center">
+          {this.state.message}
+          <br />
+          <Button.Group>
+            <a href="/" style={{ color: 'white' }}>
+              <Button positive>Home</Button>
+            </a>
+            <Button.Or />
+            <a href="/login" style={{ color: 'white' }}>
+              <Button primary>Login</Button>
+            </a>
+          </Button.Group>
+        </Header>
+      </Segment>
+    )
+  }
+
+  viewEvents = () => {
+    return (
+      <UpcomingEvents updateActiveDate={this.updateActiveDate} />
+    )
+  }
+
+  viewStories = () => {
+    return (
+      <ViewStories
+        updateGrandparent={this.updateGrandparent}
+        edit={this.state.activeItem}
+        updateGrandparentID={this.updateGrandparentID}
+        editId={this.state.editId} />
+    )
+  }
+
+  editEvent = () => {
+    return (
+      <EditEvent date={this.state.activeDate} />
+    )
+  }
+
+  editStory = () => {
+    return (
+      <EditStory editId={this.state.editId} />
+    )
+  }
+
   render() {
     const { activeItem } = this.state
 
     if (!this.state.authenticated) {
       return (
+        <HashRouter>
         <div>
           <Menu size="huge" inverted color="teal">
             <Menu.Item>
@@ -71,27 +131,15 @@ export default class AdminDashboard extends Component {
                 Logout
               </Menu.Item>
             </Menu.Menu>
-          </Menu>
-          <Segment placeholder>
-            <Header as="h3" textAlign="center">
-              {this.state.message}
-              <br />
-              <Button.Group>
-                <a href="/" style={{ color: 'white' }}>
-                  <Button positive>Home</Button>
-                </a>
-                <Button.Or />
-                <a href="/login" style={{ color: 'white' }}>
-                  <Button primary>Login</Button>
-                </a>
-              </Button.Group>
-            </Header>
-          </Segment>
-        </div>
+            </Menu>
+            <Route path="/" component={this.loginPrompt} />
+          </div>
+          </HashRouter>
       )
     }
 
     return (
+      <HashRouter>
       <div className="adminDash">
         <Menu size="huge" inverted color="teal">
           <Menu.Item>
@@ -115,11 +163,38 @@ export default class AdminDashboard extends Component {
           <DashMenu />
           {/* <Header as='h1'> {this.state.message} </Header> */}
           {/* Changed these to divs so we can work some CSS magic on them */}
-          <div className="adminPageContent">
-            <WelcomeMessage />
+            <div className="adminPageContent">
+              <Route exact path="/" component={WelcomeMessage} />
+              <Route
+                path="/EditEventTemplate"
+                component={EditEventTemplate}
+              />
+              <Route path="/AddEvent" component={AddEvent} />
+              <Route
+                path="/ViewUpcomingEvents"
+                component={this.viewEvents}
+              />
+              <Route
+                path="/VolunteerList"
+                component={VolunteerList}
+              />
+              <Route
+                path="/EditImages"
+                component={EditCarouselImages}
+              />
+              <Route
+                path="/ViewImages"
+                component={ViewAllImages}
+              />
+              <Route path="/CreateStory" component={NewStory} />
+              <Route
+                path="/ViewStories"
+                component={this.viewStories}
+              />
           </div>
         </div>
-      </div>
+        </div>
+        </HashRouter>
     )
   }
 }

--- a/packages/ui/src/Components/Dashboard/AdminDashboard.js
+++ b/packages/ui/src/Components/Dashboard/AdminDashboard.js
@@ -1,214 +1,125 @@
 import React, { Component } from 'react'
 import { Menu, Header, Segment, Button, Image } from 'semantic-ui-react'
 import Axios from 'axios'
-import VolunteerList from './VolunteerList'
-import EditCarouselImages from './Images/EditCarouselImages'
-import ViewAllImages from './Images/ViewAllImages'
-import AddEvent from './AddEvent'
-import NewStory from './Stories/NewStory'
-import ViewStories from './Stories/ViewStories'
 import WelcomeMessage from './WelcomeMessage'
-import EditStory from './Stories/EditStory'
-import EditEvent from './EditEvent'
 import Moment from 'moment'
-import UpcomingEvents from './UpcomingEvents'
-import EditEventTemplate from './EventTemplate/EditEventTemplate'
 import '../Stylesheets/AdminDashboard.css'
 import logo from '../../logoPhotos/bpdx_horizontallogo_white.png'
+import DashMenu from './DashMenu'
 
 export default class AdminDashboard extends Component {
-	state = {
-		// Default active content
-		activeItem: 'welcomeMessage',
-		activeDate: new Moment().format('MM-DD-YY'),
-		adminName: 'Anonymous',
-		authenticated: false,
-		message: 'Please Login',
-                editId : '0000'
-	}
-	async componentDidMount() {
-		//Need to generate and fill volunteer list from databases
-		Axios.get('/api/admin-dashboard')
-			.then((res) => {
-				this.setState({
-					adminName: res.data.userInfo.displayName,
-					authenticated: res.data.authenticated,
-					message: res.data.message
-				})
-			})
-			.catch((err) => {
-				console.log(err)
-			})
-	}
-
-	handleItemClick = (e, { name }) => this.setState({ activeItem: name })
-
-	updateActiveDate = (date) => {
-		this.setState({
-			activeDate: date,
-			activeItem: 'editEvent'
-		})
-	}
-  
-  updateGrandparent = (e) => this.setState({activeItem : 'editStory'})
-
-  updateGrandparentID = async (value) => {
-      await this.setState({editId: value})
-      await console.log(this.state.editId)
+  state = {
+    // Default active content
+    activeItem: 'welcomeMessage',
+    activeDate: new Moment().format('MM-DD-YY'),
+    adminName: 'Anonymous',
+    authenticated: false,
+    message: 'Please Login',
+    editId: '0000'
+  }
+  async componentDidMount() {
+    //Need to generate and fill volunteer list from databases
+    Axios.get('/api/admin-dashboard')
+      .then((res) => {
+        this.setState({
+          adminName: res.data.userInfo.displayName,
+          authenticated: res.data.authenticated,
+          message: res.data.message
+        })
+      })
+      .catch((err) => {
+        console.log(err)
+      })
   }
 
-	render() {
-		const { activeItem } = this.state
-		// Add more components to be rendered here
-		const itemsToRender = {
-			volunteerList: <VolunteerList />,
-			editCarouselImages: <EditCarouselImages />,
-			viewAllImages: <ViewAllImages />,
-			addEvent: <AddEvent />,
-			newStory: <NewStory />,
-			viewEvents: <UpcomingEvents updateActiveDate={this.updateActiveDate} />,
-			editEvent: <EditEvent date={this.state.activeDate} />,
-      welcomeMessage: <WelcomeMessage />,
-      viewStories: <ViewStories
-                       updateGrandparent={this.updateGrandparent}
-                       edit={this.state.activeItem}
-                       updateGrandparentID={this.updateGrandparentID}
-                       editId={this.state.editId} />,
-       editStory: <EditStory editId={this.state.editId}/>,
-			 editEventTemplate: <EditEventTemplate />
-		}
-       
-		if (!this.state.authenticated) {
-			return (
-				<div>
-					<Menu size="huge" inverted color="teal">
-						<Menu.Item>
-							<Image src={logo} size="small" />
-						</Menu.Item>
-						<Menu.Menu position="right">
-							<Menu.Item>
-								{/* We could change this to be whichever user is logged in */}
-								Hi {this.state.adminName}
-							</Menu.Item>
-							<Menu.Item name="logout" active={activeItem === 'logout'} onClick={this.handleItemClick}>
-								Logout
-							</Menu.Item>
-						</Menu.Menu>
-					</Menu>
-					<Segment placeholder>
-						<Header as="h3" textAlign="center">
-							{this.state.message}
-							<br />
-							<Button.Group>
-								<a href="/" style={{ color: 'white' }}>
-									<Button positive>Home</Button>
-								</a>
-								<Button.Or />
-								<a href="/login" style={{ color: 'white' }}>
-									<Button primary>Login</Button>
-								</a>
-							</Button.Group>
-						</Header>
-					</Segment>
-				</div>
-			)
-		}
+  handleItemClick = (e, { name }) => this.setState({ activeItem: name })
 
-		return (
-			<div className="adminDash">
-				<Menu size="huge" inverted color="teal">
-					<Menu.Item>
-						<Image src={logo} size="small" />
-					</Menu.Item>
-					<Menu.Menu position="right">
-						<Menu.Item>
-							{/* We could change this to be whichever user is logged in */}
-							Hi {this.state.adminName}
-						</Menu.Item>
-						<Menu.Item name="logout" active={activeItem === 'logout'} onClick={this.handleItemClick}>
-							Logout
-						</Menu.Item>
-					</Menu.Menu>
-				</Menu>
-				<div className="adminView">
-					<div className="dashMenu">
-						<Menu vertical size="huge">
-							<Menu.Item name="events">Events</Menu.Item>
-							<Menu.Menu>
-								<Menu.Item
-									name="editEventTemplate"
-									active={activeItem === 'editEventTemplate'}
-									onClick={this.handleItemClick}
-								>
-									Edit Event Template
-								</Menu.Item>
-								<Menu.Item
-									name="addEvent"
-									active={activeItem === 'addEvent'}
-									onClick={this.handleItemClick}
-								>
-									Add Event
-								</Menu.Item>
-								<Menu.Item
-									name="viewEvents"
-									active={activeItem === 'viewEvents'}
-									onClick={this.handleItemClick}
-								>
-									View Upcoming Events
-								</Menu.Item>
-							</Menu.Menu>
-							<Menu.Item
-								name="volunteerList"
-								active={activeItem === 'volunteerList'}
-								onClick={this.handleItemClick}
-							>
-								Volunteer List
-							</Menu.Item>
-							<Menu.Item name="Images">Images</Menu.Item>
-							<Menu.Menu>
-								<Menu.Item
-									name="editCarouselImages"
-									active={activeItem === 'editCarouselImages'}
-									onClick={this.handleItemClick}
-								>
-									Edit Front Page Images
-								</Menu.Item>
-								<Menu.Item
-									name="viewAllImages"
-									active={activeItem === 'viewAllImages'}
-									onClick={this.handleItemClick}
-								>
-									View All Images
-								</Menu.Item>
-							</Menu.Menu>
-							<Menu.Item name="stories">Stories</Menu.Item>
-							<Menu.Menu>
-								<Menu.Item
-									name="newStory"
-									active={activeItem === 'newStory'}
-									onClick={this.handleItemClick}
-								>
-									Create Story
-								</Menu.Item>
-								<Menu.Item name='viewStories' 
-                           active={activeItem === 'viewStories'} 
-                           onClick={this.handleItemClick}
-                 >
-                  View Stories
-								</Menu.Item>
-							</Menu.Menu>
-						</Menu>
-					</div>
-					{/* <Header as='h1'> {this.state.message} </Header> */}
-					{/* Changed these to divs so we can work some CSS magic on them */}
-					<div className="adminPageContent">
-						{
-							/* Whichever menu item is active will be the content that is shown */
-							itemsToRender[this.state.activeItem.toString()]
-						}
-					</div>
-				</div>
-			</div>
-		)
-	}
+  updateActiveDate = (date) => {
+    this.setState({
+      activeDate: date,
+      activeItem: 'editEvent'
+    })
+  }
+
+  updateGrandparent = e => this.setState({ activeItem: 'editStory' })
+
+  updateGrandparentID = async value => {
+    await this.setState({ editId: value })
+    await console.log(this.state.editId)
+  }
+
+  render() {
+    const { activeItem } = this.state
+
+    if (!this.state.authenticated) {
+      return (
+        <div>
+          <Menu size="huge" inverted color="teal">
+            <Menu.Item>
+              <Image src={logo} size="small" />
+            </Menu.Item>
+            <Menu.Menu position="right">
+              <Menu.Item>
+                {/* We could change this to be whichever user is logged in */}
+                Hi {this.state.adminName}
+              </Menu.Item>
+              <Menu.Item
+                name="logout"
+                active={activeItem === 'logout'}
+                onClick={this.handleItemClick}
+              >
+                Logout
+              </Menu.Item>
+            </Menu.Menu>
+          </Menu>
+          <Segment placeholder>
+            <Header as="h3" textAlign="center">
+              {this.state.message}
+              <br />
+              <Button.Group>
+                <a href="/" style={{ color: 'white' }}>
+                  <Button positive>Home</Button>
+                </a>
+                <Button.Or />
+                <a href="/login" style={{ color: 'white' }}>
+                  <Button primary>Login</Button>
+                </a>
+              </Button.Group>
+            </Header>
+          </Segment>
+        </div>
+      )
+    }
+
+    return (
+      <div className="adminDash">
+        <Menu size="huge" inverted color="teal">
+          <Menu.Item>
+            <Image src={logo} size="small" />
+          </Menu.Item>
+          <Menu.Menu position="right">
+            <Menu.Item>
+              {/* We could change this to be whichever user is logged in */}
+              Hi {this.state.adminName}
+            </Menu.Item>
+            <Menu.Item
+              name="logout"
+              active={activeItem === "logout"}
+              onClick={this.handleItemClick}
+            >
+              Logout
+            </Menu.Item>
+          </Menu.Menu>
+        </Menu>
+        <div className="adminView">
+          <DashMenu />
+          {/* <Header as='h1'> {this.state.message} </Header> */}
+          {/* Changed these to divs so we can work some CSS magic on them */}
+          <div className="adminPageContent">
+            <WelcomeMessage />
+          </div>
+        </div>
+      </div>
+    )
+  }
 }

--- a/packages/ui/src/Components/Dashboard/DashMenu.js
+++ b/packages/ui/src/Components/Dashboard/DashMenu.js
@@ -1,0 +1,100 @@
+import React, { Component } from "react";
+import { Menu } from "semantic-ui-react";
+import { NavLink } from "react-router-dom";
+
+export default class DashMenu extends Component {
+  state = {};
+  handleItemClick = (e, { name }) => this.setState({ activeItem: name });
+
+  render() {
+    const activeItem = this.state;
+
+    return (
+      <div className="dashMenu">
+        <Menu vertical size="huge">
+          <Menu.Item name="events">Events</Menu.Item>
+          <Menu.Menu>
+            <Menu.Item
+              name="editEventTemplate"
+              as={NavLink}
+              active={activeItem === "editEventTemplate"}
+              onClick={this.handleItemClick}
+              to={"/admin-dashboard/EditEventTemplate"}
+            >
+              Edit Event Template
+            </Menu.Item>
+            <Menu.Item
+              name="addEvent"
+              as={NavLink}
+              active={activeItem === "addEvent"}
+              onClick={this.handleItemClick}
+              to={"/admin-dashboard/AddEvent"}
+            >
+              Add Event
+            </Menu.Item>
+            <Menu.Item
+              name="viewEvents"
+              as={NavLink}
+              active={activeItem === "viewEvents"}
+              onClick={this.handleItemClick}
+              to={"/admin-dashboard/ViewUpcomingEvents"}
+            >
+              View Upcoming Events
+            </Menu.Item>
+          </Menu.Menu>
+          <Menu.Item
+            name="volunteerList"
+            as={NavLink}
+            active={activeItem === "volunteerList"}
+            onClick={this.handleItemClick}
+            to={"/admin-dashboard/VolunteerList"}
+          >
+            Volunteer List
+          </Menu.Item>
+          <Menu.Item name="Images">Images</Menu.Item>
+          <Menu.Menu>
+            <Menu.Item
+              name="editCarouselImages"
+              as={NavLink}
+              active={activeItem === "editCarouselImages"}
+              onClick={this.handleItemClick}
+              to={"/admin-dashboard/EditImages"}
+            >
+              Edit Front Page Images
+            </Menu.Item>
+            <Menu.Item
+              name="viewAllImages"
+              as={NavLink}
+              active={activeItem === "viewAllImages"}
+              onClick={this.handleItemClick}
+              to={"/admin-dashboard/ViewImages"}
+            >
+              View All Images
+            </Menu.Item>
+          </Menu.Menu>
+          <Menu.Item name="stories">Stories</Menu.Item>
+          <Menu.Menu>
+            <Menu.Item
+              name="newStory"
+              as={NavLink}
+              active={activeItem === "newStory"}
+              onClick={this.handleItemClick}
+              to={"/admin-dashboard/CreateStory"}
+            >
+              Create Story
+            </Menu.Item>
+            <Menu.Item
+              name="viewStories"
+              as={NavLink}
+              active={activeItem === "viewStories"}
+              onClick={this.handleItemClick}
+              to={"/admin-dashboard/ViewStories"}
+            >
+              View Stories
+            </Menu.Item>
+          </Menu.Menu>
+        </Menu>
+      </div>
+    );
+  }
+}

--- a/packages/ui/src/Components/Dashboard/DashMenu.js
+++ b/packages/ui/src/Components/Dashboard/DashMenu.js
@@ -19,7 +19,7 @@ export default class DashMenu extends Component {
               as={NavLink}
               active={activeItem === "editEventTemplate"}
               onClick={this.handleItemClick}
-              to={"/admin-dashboard/EditEventTemplate"}
+              to={"/EditEventTemplate"}
             >
               Edit Event Template
             </Menu.Item>
@@ -28,7 +28,7 @@ export default class DashMenu extends Component {
               as={NavLink}
               active={activeItem === "addEvent"}
               onClick={this.handleItemClick}
-              to={"/admin-dashboard/AddEvent"}
+              to={"/AddEvent"}
             >
               Add Event
             </Menu.Item>
@@ -37,7 +37,7 @@ export default class DashMenu extends Component {
               as={NavLink}
               active={activeItem === "viewEvents"}
               onClick={this.handleItemClick}
-              to={"/admin-dashboard/ViewUpcomingEvents"}
+              to={"/ViewUpcomingEvents"}
             >
               View Upcoming Events
             </Menu.Item>
@@ -47,7 +47,7 @@ export default class DashMenu extends Component {
             as={NavLink}
             active={activeItem === "volunteerList"}
             onClick={this.handleItemClick}
-            to={"/admin-dashboard/VolunteerList"}
+            to={"/VolunteerList"}
           >
             Volunteer List
           </Menu.Item>
@@ -58,7 +58,7 @@ export default class DashMenu extends Component {
               as={NavLink}
               active={activeItem === "editCarouselImages"}
               onClick={this.handleItemClick}
-              to={"/admin-dashboard/EditImages"}
+              to={"/EditImages"}
             >
               Edit Front Page Images
             </Menu.Item>
@@ -67,7 +67,7 @@ export default class DashMenu extends Component {
               as={NavLink}
               active={activeItem === "viewAllImages"}
               onClick={this.handleItemClick}
-              to={"/admin-dashboard/ViewImages"}
+              to={"/ViewImages"}
             >
               View All Images
             </Menu.Item>
@@ -79,7 +79,7 @@ export default class DashMenu extends Component {
               as={NavLink}
               active={activeItem === "newStory"}
               onClick={this.handleItemClick}
-              to={"/admin-dashboard/CreateStory"}
+              to={"/CreateStory"}
             >
               Create Story
             </Menu.Item>
@@ -88,7 +88,7 @@ export default class DashMenu extends Component {
               as={NavLink}
               active={activeItem === "viewStories"}
               onClick={this.handleItemClick}
-              to={"/admin-dashboard/ViewStories"}
+              to={"/ViewStories"}
             >
               View Stories
             </Menu.Item>


### PR DESCRIPTION
Instead of using our own single page logic to rerender what's shown in the main view of the admin dashboard, use HashRouter from React Router. This way, expected browser features like back and forward navigation and direct url navigation will work as expected. For security, only render subroutes after the user is authenticated, and redirect to login prompt when they are not. 

There's a bit of a hack present here for components where we need to pass props down from the AdminDashboard state; Route only takes component names or functions, so I've declared some functions that simply return the components we want with the props already passed in, and passed those to Route where appropriate. Some of the components, like Edit Event, don't seem to have links in the DashMenu yet, so I haven't added Routes for them, but I went ahead and created the functions so they'll be ready for later.

Also pull out the DashMenu into its own component, to tidy up the code and make AdminDashboard less tightly coupled.