### PR TITLE
feat(build): add linter and audit to precommit

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,21 @@ for the sake of our build tools).
 - To avoid consuming resources on your machine when you're done running a dev build,
   run `yarn stop` to shut down the docker container.
 
+## precommit hooks
+
+For code consistency, we have a very basic `eslint` config set to scan and fix with the 
+yarn script `yarn lint`. For convenience, this script is run as a precommit hook,
+and all changes are staged in `git`. However, be aware that this means that any files
+that you do not want to commit upstream should be properly gitignored or stashed 
+prior to running `git commit`, lest they be staged by the precommit hook. You should still
+`git add` your changed files ahead of time, or `git` may abandon the commit because
+it doesn't see any changes.
+
+The precommit also runs a 'yarn audit --fix', in an attempt to stay on top of any known
+vulnerabilities in our npm packages. This is a good precaution, but we should still be
+vigilant to any vulnerability warnings we might see in github or elsewhere, as `yarn audit`
+is not perfect.
+
 ## docker container
 
 The local dev build includes a docker container that emulates an aws s3 bucket. 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
     "build:api": "cd packages/api && yarn build",
     "clean": "run-p clean:api",
     "clean:api": "cd packages/api && yarn clean",
+    "lint": "run-p lint:api lint:ui",
+    "lint:api": "cd packages/api && yarn eslint --fix ./",
+    "lint:ui": "cd packages/ui && yarn eslint --fix ./src",
+    "precommit": "yarn lint && yarn audit --fix",
     "start": "run-p start:ui start:api",
     "start:api": "cd packages/api && yarn start",
     "start:ui": "cd packages/ui && yarn start",
@@ -30,5 +34,9 @@
   },
   "resolutions": {
     "lerna/**/tar": "^4.4.8"
+  },
+  "devDependencies": {
+    "eslint-plugin-react": "^7.13.0",
+    "husky": "^2.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint": "run-p lint:api lint:ui",
     "lint:api": "cd packages/api && yarn eslint --fix ./",
     "lint:ui": "cd packages/ui && yarn eslint --fix ./src",
-    "precommit": "yarn lint && yarn audit --fix",
+    "precommit": "yarn lint && yarn audit --fix && git add .",
     "start": "run-p start:ui start:api",
     "start:api": "cd packages/api && yarn start",
     "start:ui": "cd packages/ui && yarn start",

--- a/packages/api/.eslintrc.json
+++ b/packages/api/.eslintrc.json
@@ -1,0 +1,32 @@
+{
+    "env": {
+        "browser": true,
+        "commonjs": true,
+        "es6": true
+    },
+    "globals": {
+        "Atomics": "readonly",
+        "SharedArrayBuffer": "readonly"
+    },
+    "parserOptions": {
+        "ecmaVersion": 2018
+    },
+    "rules": {
+        "indent": [
+            "error",
+            2
+        ],
+        "linebreak-style": [
+            "error",
+            "unix"
+        ],
+        "quotes": [
+            "error",
+            "single"
+        ],
+        "semi": [
+            "error",
+            "never"
+        ]
+    }
+}

--- a/packages/api/admin.js
+++ b/packages/api/admin.js
@@ -2,103 +2,103 @@
 //Returns array of objects for all logged volunteer info for given date.
 
 getFullEventInfo = function(req, res) {
-	let client = this.dbClient
-	collection = client.db('events-form').collection('events')
-	collection.find({ date: req.query.date }, { projection: { _id: 0 } }).toArray((err, docs) => {
-		if (err) {
-			console.log(err, 'Error trying to find document')
-			res.send({
-				status: 'FAILURE'
-			})
-			return
-		} else if (docs[0] == null) {
-			console.log("Couldn't fulfill document request")
-			res.send({
-				status: 'FAILURE'
-			})
-			return
-		}
+  let client = this.dbClient
+  collection = client.db('events-form').collection('events')
+  collection.find({ date: req.query.date }, { projection: { _id: 0 } }).toArray((err, docs) => {
+    if (err) {
+      console.log(err, 'Error trying to find document')
+      res.send({
+        status: 'FAILURE'
+      })
+      return
+    } else if (docs[0] == null) {
+      console.log('Couldn\'t fulfill document request')
+      res.send({
+        status: 'FAILURE'
+      })
+      return
+    }
 
-		let response_data = []
-		docs[0].categories.forEach((category) => {
-			category.submissions.forEach((sub) => {
-				var eventObj = new Object()
-				eventObj.type = category.name
-				eventObj.desc = sub.description
-				eventObj.servings = sub.servings
-				eventObj.vegetarian = sub.vegetarian
-				eventObj.vegan = sub.vegan
-				eventObj.gluten_free = sub.gluten_free
-				eventObj.name = sub.volunteer_name
-				eventObj.phone = sub.volunteer_phone
-				eventObj.email = sub.volunteer_email
-				response_data.push(eventObj)
-			})
-		})
+    let response_data = []
+    docs[0].categories.forEach((category) => {
+      category.submissions.forEach((sub) => {
+        var eventObj = new Object()
+        eventObj.type = category.name
+        eventObj.desc = sub.description
+        eventObj.servings = sub.servings
+        eventObj.vegetarian = sub.vegetarian
+        eventObj.vegan = sub.vegan
+        eventObj.gluten_free = sub.gluten_free
+        eventObj.name = sub.volunteer_name
+        eventObj.phone = sub.volunteer_phone
+        eventObj.email = sub.volunteer_email
+        response_data.push(eventObj)
+      })
+    })
 
-		res.send({
-			status: 'SUCCESS',
-			event_info: JSON.stringify(response_data),
-			location: docs[0].location,
-			coordinator: docs[0].coordinator,
-			coordinator_phone: docs[0].coordinator_phone,
-			max_servings: docs[0].max_servings,
-			date: docs[0].date,
-			time: docs[0].time
-		})
-	})
+    res.send({
+      status: 'SUCCESS',
+      event_info: JSON.stringify(response_data),
+      location: docs[0].location,
+      coordinator: docs[0].coordinator,
+      coordinator_phone: docs[0].coordinator_phone,
+      max_servings: docs[0].max_servings,
+      date: docs[0].date,
+      time: docs[0].time
+    })
+  })
 }
 
 // Method to retrieve list of all volunteers.
 // Returns array of objects for volunteer name, email, and phone number.
 
 getVolunteerList = function(req, res) {
-	let client = this.dbClient
-	collection = client.db('volunteer_info').collection('volunteers')
-	collection.find({}, { projection: { _id: 0 } }).toArray((err, docs) => {
-		if (err) {
-			console.log(err, 'Error trying to find document')
-			res.send({
-				status: 'FAILURE'
-			})
-			return
-		} else if (docs[0] == null) {
-			console.log("Couldn't fufill document request")
-			res.send({
-				status: 'FAILURE'
-			})
-			return
-		}
-		let response_data = []
-		docs.map((volunteer) => {
-			var volunteerObj = new Object()
-			volunteerObj.name = volunteer.volunteer_name
-			volunteerObj.phone = volunteer.volunteer_phone
-			volunteerObj.email = volunteer.volunteer_email
-			response_data.push(volunteerObj)
-		})
-		res.send({
-			status: 'SUCCESS',
-			volunteer_info: JSON.stringify(response_data)
-		})
-	})
+  let client = this.dbClient
+  collection = client.db('volunteer_info').collection('volunteers')
+  collection.find({}, { projection: { _id: 0 } }).toArray((err, docs) => {
+    if (err) {
+      console.log(err, 'Error trying to find document')
+      res.send({
+        status: 'FAILURE'
+      })
+      return
+    } else if (docs[0] == null) {
+      console.log('Couldn\'t fufill document request')
+      res.send({
+        status: 'FAILURE'
+      })
+      return
+    }
+    let response_data = []
+    docs.map((volunteer) => {
+      var volunteerObj = new Object()
+      volunteerObj.name = volunteer.volunteer_name
+      volunteerObj.phone = volunteer.volunteer_phone
+      volunteerObj.email = volunteer.volunteer_email
+      response_data.push(volunteerObj)
+    })
+    res.send({
+      status: 'SUCCESS',
+      volunteer_info: JSON.stringify(response_data)
+    })
+  })
 }
 
 postAddEvent = function(req, res){
   let client = this.dbClient
-	collection = client.db("events-form").collection("events")
-  collection.find({date: "MASTER"}).toArray((err,docs) =>{
-		if(err){
-			console.log(err, "Coudln't find MASTER document")
-			res.send({
-				status: "FAILURE"
-			})
-		}else if(docs[0] == null){
-			console.log(err, "Couldn't fulfill document request")
-			res.send({
-				status: "FAILURE"
-			})
-		}else{
+  collection = client.db('events-form').collection('events')
+  collection.find({date: 'MASTER'}).toArray((err,docs) =>{
+    if(err){
+      console.log(err, 'Coudln\'t find MASTER document')
+      res.send({
+        status: 'FAILURE'
+      })
+    }else if(docs[0] == null){
+      console.log(err, 'Couldn\'t fulfill document request')
+      res.send({
+        status: 'FAILURE'
+      })
+    }else{
  	    docs[0]._id = require('mongodb').ObjectId()
  	    docs[0].date = req.body.newDate
  	    docs[0].time = req.body.newTime
@@ -107,189 +107,189 @@ postAddEvent = function(req, res){
 
 		 	collection.insertOne(docs[0])
 		 	res.send({
-				 status: "SUCCESS"
+				 status: 'SUCCESS'
 			 })
-		}
+    }
   })
 }
 
 updateEvent = function(req, res) {
-	client = this.dbClient
-	collection = client.db('events-form').collection('events')
-	let response_data = []
-	let updatedEvent = new Object()
-	updatedEvent.date = req.body.date
-	updatedEvent.time = req.body.time
-	updatedEvent.coordinator = req.body.coordinator
-	updatedEvent.coordinator_phone = req.body.coordinator_phone
-	updatedEvent.location = req.body.location
-	//updatedEvent.max_servings = req.body.max_servings
-	updatedEvent.categories = []
+  client = this.dbClient
+  collection = client.db('events-form').collection('events')
+  let response_data = []
+  let updatedEvent = new Object()
+  updatedEvent.date = req.body.date
+  updatedEvent.time = req.body.time
+  updatedEvent.coordinator = req.body.coordinator
+  updatedEvent.coordinator_phone = req.body.coordinator_phone
+  updatedEvent.location = req.body.location
+  //updatedEvent.max_servings = req.body.max_servings
+  updatedEvent.categories = []
 
-	// Get old document to get category info
-	collection.find({ date: req.body.date }, { projection: { _id: 0 } }).toArray((err, docs) => {
-		if (err) {
-			console.log(err, 'Error trying to find document')
-			res.send({
-				status: 'FAILURE'
-			})
-			return
-		} else if (docs[0] == null) {
-			console.log("Couldn't fulfill document request")
-			res.send({
-				status: 'FAILURE'
-			})
-			return
-		}
-		updatedEvent.max_servings = docs[0].max_servings
-		docs[0].categories.forEach((category) => {
-			updatedEvent.categories.push({
-				name: category.name,
-				max_signups: category.max_signups,
-				min_servings: category.min_servings,
-				min_vegan: category.min_vegan,
-				food: category.food,
-				submissions: []
-			})
-		})
+  // Get old document to get category info
+  collection.find({ date: req.body.date }, { projection: { _id: 0 } }).toArray((err, docs) => {
+    if (err) {
+      console.log(err, 'Error trying to find document')
+      res.send({
+        status: 'FAILURE'
+      })
+      return
+    } else if (docs[0] == null) {
+      console.log('Couldn\'t fulfill document request')
+      res.send({
+        status: 'FAILURE'
+      })
+      return
+    }
+    updatedEvent.max_servings = docs[0].max_servings
+    docs[0].categories.forEach((category) => {
+      updatedEvent.categories.push({
+        name: category.name,
+        max_signups: category.max_signups,
+        min_servings: category.min_servings,
+        min_vegan: category.min_vegan,
+        food: category.food,
+        submissions: []
+      })
+    })
 
-		// Load in submissions that came in from front end
-		for (var sub of req.body.submissions) {
-			if (!sub.marked_for_deletion) {
-				let cat = updatedEvent.categories.find((elem) => {
-					return elem.name === sub.type
-				})
-				cat.submissions.push({
-					description: sub.desc,
-					servings: sub.servings,
-					vegetarian: sub.vegetarian,
-					vegan: sub.vegan,
-					gluten_free: sub.gluten_free,
-					volunteer_name: sub.name,
-					volunteer_email: sub.phone,
-					volunteer_phone: sub.email
-				})
-			}
-		}
+    // Load in submissions that came in from front end
+    for (var sub of req.body.submissions) {
+      if (!sub.marked_for_deletion) {
+        let cat = updatedEvent.categories.find((elem) => {
+          return elem.name === sub.type
+        })
+        cat.submissions.push({
+          description: sub.desc,
+          servings: sub.servings,
+          vegetarian: sub.vegetarian,
+          vegan: sub.vegan,
+          gluten_free: sub.gluten_free,
+          volunteer_name: sub.name,
+          volunteer_email: sub.phone,
+          volunteer_phone: sub.email
+        })
+      }
+    }
 
-		collection.findOneAndReplace({ date: req.body.date }, updatedEvent, (err, doc) => {
-			if (err) {
-				console.log(err, 'Error trying to find or update event ')
-				res.send({
-					status: 'FAILURE'
-				})
-				return
-			} else if (doc.value === null) {
-				console.log("Couldn't find event to update")
-				res.send({
-					status: 'FAILURE'
-				})
-				return
-			} else {
-				console.log('Event updated')
-				res.send({
-					status: 'SUCCESS'
-				})
-				return
-			}
-		})
-	})
+    collection.findOneAndReplace({ date: req.body.date }, updatedEvent, (err, doc) => {
+      if (err) {
+        console.log(err, 'Error trying to find or update event ')
+        res.send({
+          status: 'FAILURE'
+        })
+        return
+      } else if (doc.value === null) {
+        console.log('Couldn\'t find event to update')
+        res.send({
+          status: 'FAILURE'
+        })
+        return
+      } else {
+        console.log('Event updated')
+        res.send({
+          status: 'SUCCESS'
+        })
+        return
+      }
+    })
+  })
 }
 
 deleteEvent = function(req, res) {
-	client = this.dbClient
-	collection = client.db('events-form').collection('events')
-	collection.findOneAndDelete({ date: req.body.date }, (err, doc) => {
-		if (err) {
-			console.log(err, 'Error trying to find event to delete')
-			res.send({
-				status: 'FAILURE'
-			})
-			return
-		} else if (doc.value === null) {
-			console.log('No event to delete with that date')
-			res.send({
-				status: 'FAILURE'
-			})
-		} else {
-			console.log('Event deleted')
-			res.send({
-				status: 'SUCCESS'
-			})
-			return
-		}
-	})
+  client = this.dbClient
+  collection = client.db('events-form').collection('events')
+  collection.findOneAndDelete({ date: req.body.date }, (err, doc) => {
+    if (err) {
+      console.log(err, 'Error trying to find event to delete')
+      res.send({
+        status: 'FAILURE'
+      })
+      return
+    } else if (doc.value === null) {
+      console.log('No event to delete with that date')
+      res.send({
+        status: 'FAILURE'
+      })
+    } else {
+      console.log('Event deleted')
+      res.send({
+        status: 'SUCCESS'
+      })
+      return
+    }
+  })
 }
 
 // Adds files to s3 bucket using filenames from user
 // Returns a success message to front end
 addPhotos = function(req, res) {
-	let AWS = this.amazon
-	const s3 = new AWS.S3({
-		endpoint: new AWS.Endpoint(process.env.S3_BUCKET),
-		s3ForcePathStyle: true,
-		accessKeyId: process.env.S3_ACCESS_KEY,
-		secretAccessKey: process.env.S3_SECRET_ACCESS_KEY
-	})
-	let file = req.body.filesToAdd
-	let buf = new Buffer(file.fileData.replace(/^data:image\/\w+;base64,/, ''), 'base64')
-	const bucket = 'beautiful-portland-carousel-photos'
-	if (req.body.isFrontPage === true) {
-		file.fileName = 'frontPage/' + file.fileName
-	}
-	const params = {
-		Bucket: bucket,
-		Key: file.fileName,
-		Body: buf
-	}
-	s3.upload(params, function(s3Err, data) {
-		if (s3Err) throw s3Err
-		console.log('File uploaded successfully')
-		res.send('upload successful')
-	})
+  let AWS = this.amazon
+  const s3 = new AWS.S3({
+    endpoint: new AWS.Endpoint(process.env.S3_BUCKET),
+    s3ForcePathStyle: true,
+    accessKeyId: process.env.S3_ACCESS_KEY,
+    secretAccessKey: process.env.S3_SECRET_ACCESS_KEY
+  })
+  let file = req.body.filesToAdd
+  let buf = new Buffer(file.fileData.replace(/^data:image\/\w+;base64,/, ''), 'base64')
+  const bucket = 'beautiful-portland-carousel-photos'
+  if (req.body.isFrontPage === true) {
+    file.fileName = 'frontPage/' + file.fileName
+  }
+  const params = {
+    Bucket: bucket,
+    Key: file.fileName,
+    Body: buf
+  }
+  s3.upload(params, function(s3Err, data) {
+    if (s3Err) throw s3Err
+    console.log('File uploaded successfully')
+    res.send('upload successful')
+  })
 }
 
 // Removes multiple photos from s3 bucket using filesnames from urls.
 // Does not return anything, but console.logs success/failure
 removePhotos = function(req, res) {
-	let AWS = this.amazon
-	const s3 = new AWS.S3({
-		endpoint: new AWS.Endpoint(process.env.S3_BUCKET),
-		s3ForcePathStyle: true,
-		accessKeyId: process.env.S3_ACCESS_KEY,
-		secretAccessKey: process.env.S3_SECRET_ACCESS_KEY
-	})
-	const bucket = 'beautiful-portland-carousel-photos'
-	// Get presigned url and parse for file name
-	const urls = req.body.urlsToRemove
-	let files = []
-	urls.forEach((url) => {
-		let file = url.split('/').pop().split('?').splice(0, 1).toString()
-		if (req.body.isFrontPage === true) {
-			files.push({ Key: '/frontPage/' + file })
-		} else {
-			files.push({ Key: file })
-		}
-	})
-	//const url = req.body.urlToRemove
-	const params = {
-		Bucket: bucket,
-		Delete: {
-			Objects: files
-		}
-	}
-	try {
-		s3.headObject(params).promise()
-		console.log('File Found in S3')
-		try {
-			s3.deleteObjects(params).promise()
-			console.log('file deleted Successfully')
-		} catch (err) {
-			console.log('ERROR in file Deleting : ' + JSON.stringify(err))
-		}
-	} catch (err) {
-		console.log('File not Found ERROR : ' + err.code)
-	}
+  let AWS = this.amazon
+  const s3 = new AWS.S3({
+    endpoint: new AWS.Endpoint(process.env.S3_BUCKET),
+    s3ForcePathStyle: true,
+    accessKeyId: process.env.S3_ACCESS_KEY,
+    secretAccessKey: process.env.S3_SECRET_ACCESS_KEY
+  })
+  const bucket = 'beautiful-portland-carousel-photos'
+  // Get presigned url and parse for file name
+  const urls = req.body.urlsToRemove
+  let files = []
+  urls.forEach((url) => {
+    let file = url.split('/').pop().split('?').splice(0, 1).toString()
+    if (req.body.isFrontPage === true) {
+      files.push({ Key: '/frontPage/' + file })
+    } else {
+      files.push({ Key: file })
+    }
+  })
+  //const url = req.body.urlToRemove
+  const params = {
+    Bucket: bucket,
+    Delete: {
+      Objects: files
+    }
+  }
+  try {
+    s3.headObject(params).promise()
+    console.log('File Found in S3')
+    try {
+      s3.deleteObjects(params).promise()
+      console.log('file deleted Successfully')
+    } catch (err) {
+      console.log('ERROR in file Deleting : ' + JSON.stringify(err))
+    }
+  } catch (err) {
+    console.log('File not Found ERROR : ' + err.code)
+  }
 }
 
 // Moves photos from in s3 bucket from front page to all photos
@@ -297,47 +297,47 @@ removePhotos = function(req, res) {
 // the item with the old key.
 // Does not return anything, but console.logs success or failure.
 removeImagesFromFrontPage = function(req, res) {
-	let AWS = this.amazon
-	const s3 = new AWS.S3({
-		endpoint: new AWS.Endpoint(process.env.S3_BUCKET),
-		s3ForcePathStyle: true,
-		accessKeyId: process.env.S3_ACCESS_KEY,
-		secretAccessKey: process.env.S3_SECRET_ACCESS_KEY
-	})
-	const bucket = 'beautiful-portland-carousel-photos'
-	// Get presigned url and parse for file name
-	const urls = req.body.urlsToRemove
-	urls.forEach((url) => {
-		let newFile = url.split('/').pop().split('?').splice(0, 1).toString()
-		// push old file to array to remove later
-		let file = 'frontPage/' + newFile
-		const params = {
-			Bucket: bucket,
-			CopySource: '/' + bucket + '/' + file,
-			Key: newFile
-		}
-		let data = s3.copyObject(params).promise()
-		// Now remove old files
-		data.then(() => {
-			console.log('file copied successfully!')
-			const params2 = {
-				Bucket: bucket,
-				Key: file
-			}
-			try {
-				s3.headObject(params2).promise()
-				console.log('File Found in S3')
-				try {
-					s3.deleteObject(params2).promise()
-					console.log('file deleted Successfully')
-				} catch (err) {
-					console.log('ERROR in file Deleting : ' + JSON.stringify(err))
-				}
-			} catch (err) {
-				console.log('File not Found ERROR : ' + err.code)
-			}
-		})
-	})
+  let AWS = this.amazon
+  const s3 = new AWS.S3({
+    endpoint: new AWS.Endpoint(process.env.S3_BUCKET),
+    s3ForcePathStyle: true,
+    accessKeyId: process.env.S3_ACCESS_KEY,
+    secretAccessKey: process.env.S3_SECRET_ACCESS_KEY
+  })
+  const bucket = 'beautiful-portland-carousel-photos'
+  // Get presigned url and parse for file name
+  const urls = req.body.urlsToRemove
+  urls.forEach((url) => {
+    let newFile = url.split('/').pop().split('?').splice(0, 1).toString()
+    // push old file to array to remove later
+    let file = 'frontPage/' + newFile
+    const params = {
+      Bucket: bucket,
+      CopySource: '/' + bucket + '/' + file,
+      Key: newFile
+    }
+    let data = s3.copyObject(params).promise()
+    // Now remove old files
+    data.then(() => {
+      console.log('file copied successfully!')
+      const params2 = {
+        Bucket: bucket,
+        Key: file
+      }
+      try {
+        s3.headObject(params2).promise()
+        console.log('File Found in S3')
+        try {
+          s3.deleteObject(params2).promise()
+          console.log('file deleted Successfully')
+        } catch (err) {
+          console.log('ERROR in file Deleting : ' + JSON.stringify(err))
+        }
+      } catch (err) {
+        console.log('File not Found ERROR : ' + err.code)
+      }
+    })
+  })
 }
 
 // Add photo to front page from already uploaded photos.
@@ -347,363 +347,363 @@ removeImagesFromFrontPage = function(req, res) {
 // Does not return anything (S3 doesn't return anything on delete),
 // but console.logs errors/success
 addFromUploaded = function(req, res) {
-	let AWS = this.amazon
-	const s3 = new AWS.S3({
-		endpoint: new AWS.Endpoint(process.env.S3_BUCKET),
-		s3ForcePathStyle: true,
-		accessKeyId: process.env.S3_ACCESS_KEY,
-		secretAccessKey: process.env.S3_SECRET_ACCESS_KEY
-	})
-	const bucket = 'beautiful-portland-carousel-photos'
-	// Get presigned url and parse for file name
-	const urls = req.body.urlsToRemove
-	urls.forEach((url) => {
-		let file = url.split('/').pop().split('?').splice(0, 1).toString()
-		// push old file to array to remove later
-		let newFile = 'frontPage/' + file
-		const params = {
-			Bucket: bucket,
-			CopySource: '/' + bucket + '/' + file,
-			Key: newFile
-		}
-		let data = s3.copyObject(params).promise()
-		// Now remove the old version of the file
-		data.then(() => {
-			console.log('file copied successfully!')
-			const params2 = {
-				Bucket: bucket,
-				Key: file
-			}
-			try {
-				s3.headObject(params2).promise()
-				console.log('File Found in S3')
-				try {
-					s3.deleteObject(params2).promise()
-					console.log('file deleted Successfully')
-				} catch (err) {
-					console.log('ERROR in file Deleting : ' + JSON.stringify(err))
-				}
-			} catch (err) {
-				console.log('File not Found ERROR : ' + err.code)
-			}
-		})
-	})
+  let AWS = this.amazon
+  const s3 = new AWS.S3({
+    endpoint: new AWS.Endpoint(process.env.S3_BUCKET),
+    s3ForcePathStyle: true,
+    accessKeyId: process.env.S3_ACCESS_KEY,
+    secretAccessKey: process.env.S3_SECRET_ACCESS_KEY
+  })
+  const bucket = 'beautiful-portland-carousel-photos'
+  // Get presigned url and parse for file name
+  const urls = req.body.urlsToRemove
+  urls.forEach((url) => {
+    let file = url.split('/').pop().split('?').splice(0, 1).toString()
+    // push old file to array to remove later
+    let newFile = 'frontPage/' + file
+    const params = {
+      Bucket: bucket,
+      CopySource: '/' + bucket + '/' + file,
+      Key: newFile
+    }
+    let data = s3.copyObject(params).promise()
+    // Now remove the old version of the file
+    data.then(() => {
+      console.log('file copied successfully!')
+      const params2 = {
+        Bucket: bucket,
+        Key: file
+      }
+      try {
+        s3.headObject(params2).promise()
+        console.log('File Found in S3')
+        try {
+          s3.deleteObject(params2).promise()
+          console.log('file deleted Successfully')
+        } catch (err) {
+          console.log('ERROR in file Deleting : ' + JSON.stringify(err))
+        }
+      } catch (err) {
+        console.log('File not Found ERROR : ' + err.code)
+      }
+    })
+  })
 }
 
 addNewDraft = function(req, res) {
-	let client = this.dbClient
-	collection = client.db('stories_example1').collection('drafts')
-	collection.updateOne(
-		{ edited_timestamp: req.body.edited_timestamp },
-		{
-			$set: {
-				edited_timestamp: new Date(),
-				publish_status: req.body.publish_status,
-				title: req.body.title,
-				hook: req.body.hook,
-				content: req.body.content
-			}
-		},
-		{ upsert: true },
-		function(err, obj) {
-			if (err) throw err
-			else res.end('Draft Saved')
-		}
-	)
+  let client = this.dbClient
+  collection = client.db('stories_example1').collection('drafts')
+  collection.updateOne(
+    { edited_timestamp: req.body.edited_timestamp },
+    {
+      $set: {
+        edited_timestamp: new Date(),
+        publish_status: req.body.publish_status,
+        title: req.body.title,
+        hook: req.body.hook,
+        content: req.body.content
+      }
+    },
+    { upsert: true },
+    function(err, obj) {
+      if (err) throw err
+      else res.end('Draft Saved')
+    }
+  )
 }
 
 addNewPublished = function(req, res) {
-	let client = this.dbClient
-	collection = client.db('stories_example1').collection('published')
-	collection.updateOne(
-		{ edited_timestamp: req.body.edited_timestamp },
-		{
-			$set: {
-				edited_timestamp: new Date(),
-				publish_status: req.body.publish_status,
-				title: req.body.title,
-				hook: req.body.hook,
-				content: req.body.content
-			}
-		},
-		{ upsert: true },
-		function(err, obj) {
-			if (err) throw err
-			else res.end('Story Published')
-		}
-	)
+  let client = this.dbClient
+  collection = client.db('stories_example1').collection('published')
+  collection.updateOne(
+    { edited_timestamp: req.body.edited_timestamp },
+    {
+      $set: {
+        edited_timestamp: new Date(),
+        publish_status: req.body.publish_status,
+        title: req.body.title,
+        hook: req.body.hook,
+        content: req.body.content
+      }
+    },
+    { upsert: true },
+    function(err, obj) {
+      if (err) throw err
+      else res.end('Story Published')
+    }
+  )
 }
 
 editedStory = function(req,res) {
-	var ObjectId = require('mongodb').ObjectID
-	let client = this.dbClient
-	if(req.body.publish_status === true){
-		collection = client.db('stories_example1').collection('published')
-	} else {
-		collection = client.db('stories_example1').collection('drafts')
-	}
-	collection.updateOne(
-		{_id: ObjectId(req.body._id)},
-		{
-			$set: {
-				edited_timestamp: new Date(),
-				publish_status: req.body.publish_status,
-				title: req.body.title,
-				hook: req.body.hook,
-				content: req.body.content
-			}
-		},
-		{ upsert: true },
-		function(err, obj) {
-			if (err) throw err
-			else res.end('Story has been edited')
-		}
+  var ObjectId = require('mongodb').ObjectID
+  let client = this.dbClient
+  if(req.body.publish_status === true){
+    collection = client.db('stories_example1').collection('published')
+  } else {
+    collection = client.db('stories_example1').collection('drafts')
+  }
+  collection.updateOne(
+    {_id: ObjectId(req.body._id)},
+    {
+      $set: {
+        edited_timestamp: new Date(),
+        publish_status: req.body.publish_status,
+        title: req.body.title,
+        hook: req.body.hook,
+        content: req.body.content
+      }
+    },
+    { upsert: true },
+    function(err, obj) {
+      if (err) throw err
+      else res.end('Story has been edited')
+    }
 
-	)
+  )
 }
 
 getPublishedStory = function(req, res) {
-	console.log("publish page " + req.query.page)
-	let skips = (req.query.page - 1) * 5
-	let client = this.dbClient
-	collection = client.db('stories_example1').collection('published')
-	collection.find().sort({ _id: -1 }).skip(skips).limit(5).toArray((err, docs) => {
-		if (err) {
-			console.log(err, 'Error trying to find published Stories')
-			res.send({
-				status: 'FAILURE'
-			})
-			return
-		} else if (docs[0] == null) {
-			console.log("Couldn't fufill Story request")
-			res.send({
-				status: 'FAILURE'
-			})
-			return
-		}
-		let response_data = []
-		docs.map((pubStory) => {
-			var publishObj = new Object()
-			publishObj._id = pubStory._id
-			publishObj.edited_timestamp = pubStory.edited_timestamp
-			publishObj.title = pubStory.title
-			publishObj.hook = pubStory.hook
-			publishObj.content = pubStory.content
-			publishObj.public_status = pubStory.public_status
-			response_data.push(pubStory)
-		})
-		res.send({
-			status: 'SUCCESS',
-			published_info: JSON.stringify(response_data)
-		})
-	})
+  console.log('publish page ' + req.query.page)
+  let skips = (req.query.page - 1) * 5
+  let client = this.dbClient
+  collection = client.db('stories_example1').collection('published')
+  collection.find().sort({ _id: -1 }).skip(skips).limit(5).toArray((err, docs) => {
+    if (err) {
+      console.log(err, 'Error trying to find published Stories')
+      res.send({
+        status: 'FAILURE'
+      })
+      return
+    } else if (docs[0] == null) {
+      console.log('Couldn\'t fufill Story request')
+      res.send({
+        status: 'FAILURE'
+      })
+      return
+    }
+    let response_data = []
+    docs.map((pubStory) => {
+      var publishObj = new Object()
+      publishObj._id = pubStory._id
+      publishObj.edited_timestamp = pubStory.edited_timestamp
+      publishObj.title = pubStory.title
+      publishObj.hook = pubStory.hook
+      publishObj.content = pubStory.content
+      publishObj.public_status = pubStory.public_status
+      response_data.push(pubStory)
+    })
+    res.send({
+      status: 'SUCCESS',
+      published_info: JSON.stringify(response_data)
+    })
+  })
 }
 
 getDraftedStories = function(req, res) {
-	console.log("draft page " + req.query.page)
-	let skips = (req.query.page - 1) * 5
-	let client = this.dbClient
-	collection = client.db('stories_example1').collection('drafts')
-	collection.find().sort({ _id: -1 }).skip(skips).limit(5).toArray((err, docs) => {
-		if (err) {
-			console.log(err, 'Error trying to find drafted Stories')
-			res.send({
-				status: 'FAILURE'
-			})
-			return
-		} else if (docs[0] == null) {
-			console.log("Couldn't fufill Story request")
-			res.send({
-				status: 'FAILURE'
-			})
-			return
-		}
-		let response_data = []
-		docs.map((draftStory) => {
-			var draftObj = new Object()
-			draftObj.original_timestamp = draftStory._id.getTimestamp()
-			draftObj.edited_timestamp = draftStory.edited_timestamp
-			draftObj.title = draftStory.title
-			draftObj.hook = draftStory.hook
-			draftObj.content = draftStory.content
-			draftObj.public_status = draftStory.public_status
-			response_data.push(draftStory)
-		})
-		res.send({
-			status: 'SUCCESS',
-			draft_info: JSON.stringify(response_data)
-		})
-	})
+  console.log('draft page ' + req.query.page)
+  let skips = (req.query.page - 1) * 5
+  let client = this.dbClient
+  collection = client.db('stories_example1').collection('drafts')
+  collection.find().sort({ _id: -1 }).skip(skips).limit(5).toArray((err, docs) => {
+    if (err) {
+      console.log(err, 'Error trying to find drafted Stories')
+      res.send({
+        status: 'FAILURE'
+      })
+      return
+    } else if (docs[0] == null) {
+      console.log('Couldn\'t fufill Story request')
+      res.send({
+        status: 'FAILURE'
+      })
+      return
+    }
+    let response_data = []
+    docs.map((draftStory) => {
+      var draftObj = new Object()
+      draftObj.original_timestamp = draftStory._id.getTimestamp()
+      draftObj.edited_timestamp = draftStory.edited_timestamp
+      draftObj.title = draftStory.title
+      draftObj.hook = draftStory.hook
+      draftObj.content = draftStory.content
+      draftObj.public_status = draftStory.public_status
+      response_data.push(draftStory)
+    })
+    res.send({
+      status: 'SUCCESS',
+      draft_info: JSON.stringify(response_data)
+    })
+  })
 }
 
 deleteDraft = function(req, res) {
-	var ObjectId = require('mongodb').ObjectID
-	let client = this.dbClient
-	collection = client.db('stories_example1').collection('drafts')
-	collection.deleteOne(
-		{
-			_id: ObjectId(req.body.deleteId)
-		},
-		function(err, obj) {
-			if (err) throw err
-			else res.end('Draft Deleted Successful')
-		}
-	)
+  var ObjectId = require('mongodb').ObjectID
+  let client = this.dbClient
+  collection = client.db('stories_example1').collection('drafts')
+  collection.deleteOne(
+    {
+      _id: ObjectId(req.body.deleteId)
+    },
+    function(err, obj) {
+      if (err) throw err
+      else res.end('Draft Deleted Successful')
+    }
+  )
 }
 
 deletePublish = function(req, res) {
-	var ObjectId = require('mongodb').ObjectID
-	let client = this.dbClient
-	collection = client.db('stories_example1').collection('published')
-	collection.deleteOne(
-		{
-			_id: ObjectId(req.body.deleteId)
-		},
-		function(err, obj) {
-			if (err) throw err
-			else res.end('Published Story Deleted Successful')
-		}
-	)
+  var ObjectId = require('mongodb').ObjectID
+  let client = this.dbClient
+  collection = client.db('stories_example1').collection('published')
+  collection.deleteOne(
+    {
+      _id: ObjectId(req.body.deleteId)
+    },
+    function(err, obj) {
+      if (err) throw err
+      else res.end('Published Story Deleted Successful')
+    }
+  )
 }
 
 getStoryEdit = function(req, res) {
-	var ObjectId = require('mongodb').ObjectID
-	let client = this.dbClient
-	collection = client.db('stories_example1').collection('published')
-	collection.findOne({ _id: ObjectId(req.body.id) }, function(err, result) {
-	if (err) {
-		throw err
-	} else if (!result) {
-		collection = client.db('stories_example1').collection('drafts')
-		collection.findOne({ _id: ObjectId(req.body.id) }, function(e, r) {
-		if (err) {
-			throw err
-		} else {
-			res.send(r)
-		}
-		})
-		} else {
-			res.send(result)
-		}
-	})
+  var ObjectId = require('mongodb').ObjectID
+  let client = this.dbClient
+  collection = client.db('stories_example1').collection('published')
+  collection.findOne({ _id: ObjectId(req.body.id) }, function(err, result) {
+    if (err) {
+      throw err
+    } else if (!result) {
+      collection = client.db('stories_example1').collection('drafts')
+      collection.findOne({ _id: ObjectId(req.body.id) }, function(e, r) {
+        if (err) {
+          throw err
+        } else {
+          res.send(r)
+        }
+      })
+    } else {
+      res.send(result)
+    }
+  })
 }
 
 getStoryCount = async function(req, res) {
-	let client = this.dbClient
-	let response_data = []
-	collection = client.db('stories_example1').collection('published')
-	let pubResult = await collection.countDocuments({})
+  let client = this.dbClient
+  let response_data = []
+  collection = client.db('stories_example1').collection('published')
+  let pubResult = await collection.countDocuments({})
 		
-	collection = client.db('stories_example1').collection('drafts')
+  collection = client.db('stories_example1').collection('drafts')
 	    draftResult = await collection.countDocuments({})
-		var countObj = new Object()
-		countObj.draftCount = draftResult
-		countObj.publishCount = pubResult
-		response_data.push(countObj)
-	console.log(response_data)
-	res.send({
-		status: 'SUCESS',
-		count_info: JSON.stringify(response_data)
-	})
+  var countObj = new Object()
+  countObj.draftCount = draftResult
+  countObj.publishCount = pubResult
+  response_data.push(countObj)
+  console.log(response_data)
+  res.send({
+    status: 'SUCESS',
+    count_info: JSON.stringify(response_data)
+  })
 }
 
 editEventTemplate = function(req, res) {
-	let client = this.dbClient
-	collection = client.db("events-form").collection("events")
-	collection.findOneAndUpdate({ date : "MASTER2" },
-	{$set: {
-		"location" : req.body.location,
-		"time" : req.body.time,
-		"max_servings" : req.body.max_servings,
-		"categories": [{
-			"name" : req.body.name,
-			"max_signups" : req.body.max_signups,
-			"min_servings" : req.body.min_servings,
-			"food" : req.body.food,
-			"min_vegan" : req.body.min_vegan
-		}]
-	}},{ upsert : true },
-	function(err,doc) {
-		if(err){
-			console.log(err, "Error trying to find master template to edit")
-			res.send({
-				status: 'FAILURE'
-			})
-			return
-		}else{
-			console.log("SUCCESS! [" + req.body.name +"] has been updated")
-			res.end("Template Updated")
-		}}
-	)
+  let client = this.dbClient
+  collection = client.db('events-form').collection('events')
+  collection.findOneAndUpdate({ date : 'MASTER2' },
+    {$set: {
+      'location' : req.body.location,
+      'time' : req.body.time,
+      'max_servings' : req.body.max_servings,
+      'categories': [{
+        'name' : req.body.name,
+        'max_signups' : req.body.max_signups,
+        'min_servings' : req.body.min_servings,
+        'food' : req.body.food,
+        'min_vegan' : req.body.min_vegan
+      }]
+    }},{ upsert : true },
+    function(err,doc) {
+      if(err){
+        console.log(err, 'Error trying to find master template to edit')
+        res.send({
+          status: 'FAILURE'
+        })
+        return
+      }else{
+        console.log('SUCCESS! [' + req.body.name +'] has been updated')
+        res.end('Template Updated')
+      }}
+  )
 }
 
 getEventTemplate = function(req, res) {
-	let client = this.dbClient
-	collection = client.db("events-form").collection("events")
-	collection.find({date: "MASTER"}, {projection:{ _id: 0}}).toArray((err, docs) => {
-		if(err) {
-			console.log(err, "Error trying to get info from master template")
-			res.send({
-				status: 'FAILURE'
-			})
-			return
-		} else if(docs[0] == null) {
-			console.log("Couldn't fulfill master template request")
-			res.send({
-				status: 'FAILURE'
-			})
-			return
-		}
+  let client = this.dbClient
+  collection = client.db('events-form').collection('events')
+  collection.find({date: 'MASTER'}, {projection:{ _id: 0}}).toArray((err, docs) => {
+    if(err) {
+      console.log(err, 'Error trying to get info from master template')
+      res.send({
+        status: 'FAILURE'
+      })
+      return
+    } else if(docs[0] == null) {
+      console.log('Couldn\'t fulfill master template request')
+      res.send({
+        status: 'FAILURE'
+      })
+      return
+    }
 
-		// console.log(docs[0])
-		let response_data = []
-		docs[0].categories.forEach(category => {
-			var masterObj = new Object()
-			masterObj.name = category.name
-			masterObj.food = category.food
-			masterObj.max_signups = category.max_signups
-			masterObj.min_servings = category.min_servings
-			masterObj.min_vegan = category.min_vegan
-			response_data.push(masterObj)
-		})
+    // console.log(docs[0])
+    let response_data = []
+    docs[0].categories.forEach(category => {
+      var masterObj = new Object()
+      masterObj.name = category.name
+      masterObj.food = category.food
+      masterObj.max_signups = category.max_signups
+      masterObj.min_servings = category.min_servings
+      masterObj.min_vegan = category.min_vegan
+      response_data.push(masterObj)
+    })
 
-		res.send({
-			status: 'SUCCESS',
-			event_info: JSON.stringify(response_data),
-			location: docs[0].location,
-			time: docs[0].time,
-			max_servings: docs[0].max_servings
-		})
-	})
+    res.send({
+      status: 'SUCCESS',
+      event_info: JSON.stringify(response_data),
+      location: docs[0].location,
+      time: docs[0].time,
+      max_servings: docs[0].max_servings
+    })
+  })
 }
 
 deleteEventTemplate = function(req, res) {
-	client = this.dbClient
-	console.log(req.body.category)
-	collection = client.db('events-form').collection('events')
-	collection.findOneAndUpdate({ date: 'MASTER2'},
-	{$pull:{
-		"categories":{
-			"name" : req.body.category
-		}
-	}}, (err, doc) => {
-		if (err) {
-			console.log(err, 'Error trying to find master template to delete')
-			res.send({
-				status: 'FAILURE'
-			})
-			return
-		} else if (doc.value === null) {
-			console.log('No master template to delete with that category')
-			res.send({
-				status: 'FAILURE'
-			})
-		} else {
-			console.log("SUCCESS! [" + req.body.category +"] has been deleted from the master template")
-			res.end("SUCCESS")
-			return
-		}
-	})
+  client = this.dbClient
+  console.log(req.body.category)
+  collection = client.db('events-form').collection('events')
+  collection.findOneAndUpdate({ date: 'MASTER2'},
+    {$pull:{
+      'categories':{
+        'name' : req.body.category
+      }
+    }}, (err, doc) => {
+      if (err) {
+        console.log(err, 'Error trying to find master template to delete')
+        res.send({
+          status: 'FAILURE'
+        })
+        return
+      } else if (doc.value === null) {
+        console.log('No master template to delete with that category')
+        res.send({
+          status: 'FAILURE'
+        })
+      } else {
+        console.log('SUCCESS! [' + req.body.category +'] has been deleted from the master template')
+        res.end('SUCCESS')
+        return
+      }
+    })
 }
 
 module.exports.addPhotos = addPhotos

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -24,6 +24,7 @@
     "aws-sdk": "^2.413.0",
     "cookie-session": "^1.3.3",
     "dotenv": "^7.0.0",
+    "eslint": "^5.16.0",
     "express": "^4.16.4",
     "mongodb": "^3.1.13",
     "perish": "^1.0.2",

--- a/packages/api/scripts/initialize-s3.js
+++ b/packages/api/scripts/initialize-s3.js
@@ -3,27 +3,27 @@ const retry = require('promise-retry')
 const AWS = require('aws-sdk')
 
 async function go() {
-    const s3Client = new AWS.S3({
-      endpoint: new AWS.Endpoint('http://localhost:9001'),
-      s3ForcePathStyle: true,
-      accessKeyId: 'b@dpass',
-      secretAccessKey: 'r3alb@dpass'
-    })
-    const bucketNames = ['beautiful-portland-carousel-photos']
-    await retry(
-      tryAgain => ensureS3Ready(s3Client).catch(error => tryAgain(error)),
-      { factor: 1 }
-    )
-    await Promise.all(bucketNames.map(async name => { createBucket(s3Client, name) } ))
-  }
+  const s3Client = new AWS.S3({
+    endpoint: new AWS.Endpoint('http://localhost:9001'),
+    s3ForcePathStyle: true,
+    accessKeyId: 'b@dpass',
+    secretAccessKey: 'r3alb@dpass'
+  })
+  const bucketNames = ['beautiful-portland-carousel-photos']
+  await retry(
+    tryAgain => ensureS3Ready(s3Client).catch(error => tryAgain(error)),
+    { factor: 1 }
+  )
+  await Promise.all(bucketNames.map(async name => { createBucket(s3Client, name) } ))
+}
   
-  async function ensureS3Ready(s3Client) {
-    return s3Client.listBuckets().promise()
-  }
+async function ensureS3Ready(s3Client) {
+  return s3Client.listBuckets().promise()
+}
   
-  async function createBucket(s3Client, bucketName) {
-    console.log(`creating bucket ${bucketName}`)
-    return s3Client.createBucket({ Bucket: bucketName }).promise()
-  }
+async function createBucket(s3Client, bucketName) {
+  console.log(`creating bucket ${bucketName}`)
+  return s3Client.createBucket({ Bucket: bucketName }).promise()
+}
   
-  go()
+go()

--- a/packages/api/server.js
+++ b/packages/api/server.js
@@ -15,15 +15,15 @@ const visitorHandlers = require('./visitor')
 const adminHandlers = require('./admin')
 
 if (process.env.NODE_ENV !== 'production') {
-  require('dotenv').config();
+  require('dotenv').config()
 }
 
 app.use(bodyParser.json({limit:'50mb', extended: true}))
 app.use(bodyParser.urlencoded({limit: '50mb', extended: true}))
 app.use(session({
-    secret: 'keyboard cat',
-    resave: false,
-    saveUninitialized: false
+  secret: 'keyboard cat',
+  resave: false,
+  saveUninitialized: false
 }))
 app.use(cookieParser())
 app.use(passport.initialize())
@@ -32,10 +32,10 @@ app.use(passport.session())
 //Connects to MongoDB
 const client = new MongoClient(uri, { useNewUrlParser: true })
 client.connect((err) => {
-    if (err) {
-        console.log(err, "Connection to db failed")
-        return
-    }
+  if (err) {
+    console.log(err, 'Connection to db failed')
+    return
+  }
 })
 
 // Console.log to show server up and running in terminal
@@ -43,27 +43,27 @@ app.listen(port, () => console.log('Listening on port ' + port + '...'))
 
 // serialize the user for the session
 passport.serializeUser(function(user, done) {
-    done(null, user)
+  done(null, user)
 })
 
 // deserialize the user
 passport.deserializeUser(function(obj, done) {
-    done(null, obj)
+  done(null, obj)
 })
 
 // passport config
 passport.use(new GoogleStrategy(
-    authConfig.google,
-    function(accessToken, refreshToken, profile, done) {
-      return done(null, profile)
-    }
+  authConfig.google,
+  function(accessToken, refreshToken, profile, done) {
+    return done(null, profile)
+  }
 ))
 
 // let google to authentication the admin
 app.get('/auth/google',
   passport.authenticate('google', {
     scope: ['openid', 'email', 'profile']
-}))
+  }))
 
 // the callback after google authenticated the admin
 app.get('/auth/google/callback',

--- a/packages/api/visitor.js
+++ b/packages/api/visitor.js
@@ -1,146 +1,146 @@
 // Get request to S3 container to get photos for image carousel
 // Returns a list of presigned image urls from the s3 bucket.
 homeImages = function(req, res) {
-    let AWS = this.amazon
-    const s3 = new AWS.S3({
-        endpoint: new AWS.Endpoint(process.env.S3_BUCKET),
-        s3ForcePathStyle: true,
-        accessKeyId: process.env.S3_ACCESS_KEY,
-        secretAccessKey: process.env.S3_SECRET_ACCESS_KEY
+  let AWS = this.amazon
+  const s3 = new AWS.S3({
+    endpoint: new AWS.Endpoint(process.env.S3_BUCKET),
+    s3ForcePathStyle: true,
+    accessKeyId: process.env.S3_ACCESS_KEY,
+    secretAccessKey: process.env.S3_SECRET_ACCESS_KEY
+  })
+  const bucket = 'beautiful-portland-carousel-photos'
+  let imageUrls = []
+  // Checks for if on front page (or editing front page images)
+  let isFront = req.query.isFrontPage
+  // Checks for if we need non-front page images only (editing front page images on admin side)
+  let needNotFront = req.query.needNotOnFront
+  let data = s3.listObjects({Bucket:bucket}).promise()
+  data.then(data => {
+    data.Contents.forEach((item) => {
+      let keyString = JSON.stringify(item.Key)
+      // Need images not on front page
+      if(needNotFront === 'true') {
+        if(keyString.indexOf('frontPage') === -1) {
+          let key = item.Key
+          imageUrls = imageUrls.concat(s3.getSignedUrl('getObject', {
+            Bucket: bucket,
+            Key: key,
+          }))
+        }
+      }
+      // Only get images for all images OR if we are on the front page
+      // (isFront === 'true'), only get images in frontPage folder
+      else if(isFront === 'false' || (keyString.indexOf('frontPage') !== -1)) {
+        let key = item.Key
+        imageUrls = imageUrls.concat(s3.getSignedUrl('getObject', {
+          Bucket: bucket,
+          Key: key,
+        }))
+      }   
     })
-    const bucket = 'beautiful-portland-carousel-photos'
-    let imageUrls = []
-    // Checks for if on front page (or editing front page images)
-    let isFront = req.query.isFrontPage
-    // Checks for if we need non-front page images only (editing front page images on admin side)
-    let needNotFront = req.query.needNotOnFront
-    let data = s3.listObjects({Bucket:bucket}).promise()
-    data.then(data => {
-        data.Contents.forEach((item) => {
-            let keyString = JSON.stringify(item.Key)
-            // Need images not on front page
-            if(needNotFront === 'true') {
-                if(keyString.indexOf('frontPage') === -1) {
-                    let key = item.Key
-                    imageUrls = imageUrls.concat(s3.getSignedUrl('getObject', {
-                        Bucket: bucket,
-                        Key: key,
-                    }))
-                }
-            }
-            // Only get images for all images OR if we are on the front page
-            // (isFront === 'true'), only get images in frontPage folder
-            else if(isFront === 'false' || (keyString.indexOf('frontPage') !== -1)) {
-                let key = item.Key
-                imageUrls = imageUrls.concat(s3.getSignedUrl('getObject', {
-                    Bucket: bucket,
-                    Key: key,
-                }))
-            }   
-        })
-        res.send(imageUrls)
-    })
+    res.send(imageUrls)
+  })
     .catch(err => {
-        console.log(err)
+      console.log(err)
     })
 }
 
 // Called by '/volunteer-form' to get category info for an event, to properly limit signups
 volunteerFormGetEventInfo = function(req, res) {
-    let client = this.dbClient
-    collection = client.db("events-form").collection("events")
-    collection.find({date: req.query.date}).toArray((err, docs) => {
-        if(err) {
-            console.log(err, "Error trying to find document")
-            res.send({
-                status: 'FAILURE'
-            })
-            return
-        } else if(docs.length === 0) {
-            console.log("Couldn't fulfill a document request")
-            res.send({
-                status: 'FAILURE'
-            })
-            return
-        }
+  let client = this.dbClient
+  collection = client.db('events-form').collection('events')
+  collection.find({date: req.query.date}).toArray((err, docs) => {
+    if(err) {
+      console.log(err, 'Error trying to find document')
+      res.send({
+        status: 'FAILURE'
+      })
+      return
+    } else if(docs.length === 0) {
+      console.log('Couldn\'t fulfill a document request')
+      res.send({
+        status: 'FAILURE'
+      })
+      return
+    }
 
-        let i = 0, response_data = []
-        docs[0].categories.forEach(category => {
-            response_data.push({
-                type: category.name,
-                max_signups: category.max_signups,
-                real_signups: 0,
-                min_servings: category.min_servings,
-                min_vegan_servings: Math.ceil(Math.floor(category.min_servings/3) / 10) * 10,
-                food: category.food,
-                min_vegan: category.min_vegan,
-                real_vegan: 0, 
-                servings: 0
-            })
-            category.submissions.forEach(sub => {
-                response_data[i].real_signups++
-                if(response_data[i].food && sub.vegan) {
-                    response_data[i].real_vegan++
-                }
-                response_data[i].servings += sub.servings
-            })
-            i++
-        })
-        res.send({
-            status: 'SUCCESS',
-            event_info: JSON.stringify(response_data),
-            location: docs[0].location,
-            coordinator: docs[0].coordinator,
-            coordinator_phone: docs[0].coordinator_phone,
-            max_servings: docs[0].max_servings
-        })
+    let i = 0, response_data = []
+    docs[0].categories.forEach(category => {
+      response_data.push({
+        type: category.name,
+        max_signups: category.max_signups,
+        real_signups: 0,
+        min_servings: category.min_servings,
+        min_vegan_servings: Math.ceil(Math.floor(category.min_servings/3) / 10) * 10,
+        food: category.food,
+        min_vegan: category.min_vegan,
+        real_vegan: 0, 
+        servings: 0
+      })
+      category.submissions.forEach(sub => {
+        response_data[i].real_signups++
+        if(response_data[i].food && sub.vegan) {
+          response_data[i].real_vegan++
+        }
+        response_data[i].servings += sub.servings
+      })
+      i++
     })
+    res.send({
+      status: 'SUCCESS',
+      event_info: JSON.stringify(response_data),
+      location: docs[0].location,
+      coordinator: docs[0].coordinator,
+      coordinator_phone: docs[0].coordinator_phone,
+      max_servings: docs[0].max_servings
+    })
+  })
 }
 
 // Catch frontend POST request from volunteer signup form
 volunteerFormSubmit = function(req, res) {
-    let client = this.dbClient
-    //updates Document in mongodb
-    collection = client.db("events-form").collection("events")
-    collection.updateOne(
-      {$and: [{date:req.body.date}, {"categories.name":req.body.type}]},
-      {$push: {"categories.$.submissions": {
-         "description" : req.body.description,
-         "servings" : JSON.parse(req.body.servings),
-         "vegetarian": req.body.vegetarian,
-         "vegan": req.body.vegan,
-         "gluten_free": req.body.gluten_free,
-         "volunteer_name": req.body.volunteer_name,
-         "volunteer_phone": req.body.volunteer_phone,
-         "volunteer_email": req.body.volunteer_email
-        }}}, //$push
-        function(err,resu){
-            if (err)
-                console.log(err,"Event Not Added")
-            else{
-                if(resu.result.nModified == 1){
-                    console.log("Event Modified -- Added New Submission")
-                    collection = client.db("volunteer_info").collection("volunteers")
-                    collection.updateOne(
-                        {"volunteer_email" : req.body.volunteer_email},
-                        {$set: {"volunteer_email" : req.body.volunteer_email,
-                                "volunteer_name" : req.body.volunteer_name,
-                                "volunteer_phone" : req.body.volunteer_phone}},
-                        {upsert : true},
-                        function(err, result) {
-                            if(err)
-                                console.log(err, "Volunteer Not Updated")
-                            else{
-                                console.log("Volunteer Added or Updated")
-                                res.send("All Collections Updated")
-                            }
-                        }
-                    )
-                }else{
-                    console.log("Error: Event Not Updated -- No matching date or type found -- Volunteer also not updated")
-                    res.send("No Collections Updated")
-                }
+  let client = this.dbClient
+  //updates Document in mongodb
+  collection = client.db('events-form').collection('events')
+  collection.updateOne(
+    {$and: [{date:req.body.date}, {'categories.name':req.body.type}]},
+    {$push: {'categories.$.submissions': {
+      'description' : req.body.description,
+      'servings' : JSON.parse(req.body.servings),
+      'vegetarian': req.body.vegetarian,
+      'vegan': req.body.vegan,
+      'gluten_free': req.body.gluten_free,
+      'volunteer_name': req.body.volunteer_name,
+      'volunteer_phone': req.body.volunteer_phone,
+      'volunteer_email': req.body.volunteer_email
+    }}}, //$push
+    function(err,resu){
+      if (err)
+        console.log(err,'Event Not Added')
+      else{
+        if(resu.result.nModified == 1){
+          console.log('Event Modified -- Added New Submission')
+          collection = client.db('volunteer_info').collection('volunteers')
+          collection.updateOne(
+            {'volunteer_email' : req.body.volunteer_email},
+            {$set: {'volunteer_email' : req.body.volunteer_email,
+              'volunteer_name' : req.body.volunteer_name,
+              'volunteer_phone' : req.body.volunteer_phone}},
+            {upsert : true},
+            function(err, result) {
+              if(err)
+                console.log(err, 'Volunteer Not Updated')
+              else{
+                console.log('Volunteer Added or Updated')
+                res.send('All Collections Updated')
+              }
             }
+          )
+        }else{
+          console.log('Error: Event Not Updated -- No matching date or type found -- Volunteer also not updated')
+          res.send('No Collections Updated')
+        }
+      }
     })
 }
 

--- a/packages/api/yarn.lock
+++ b/packages/api/yarn.lock
@@ -2,6 +2,22 @@
 # yarn lockfile v1
 
 
+"@babel/code-frame@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0.tgz#06e2ab19bdb535385559aabb5ba59729482800f8"
+  integrity sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==
+  dependencies:
+    "@babel/highlight" "^7.0.0"
+
+"@babel/highlight@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0.tgz#f710c38c8d458e6dd9a201afb637fcb781ce99e4"
+  integrity sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==
+  dependencies:
+    chalk "^2.0.0"
+    esutils "^2.0.2"
+    js-tokens "^4.0.0"
+
 "@types/promise-retry@^1.1.3":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@types/promise-retry/-/promise-retry-1.1.3.tgz#baab427419da9088a1d2f21bf56249c21b3dd43c"
@@ -22,10 +38,64 @@ accepts@~1.3.5:
     mime-types "~2.1.18"
     negotiator "0.6.1"
 
+acorn-jsx@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.0.1.tgz#32a064fd925429216a09b141102bfdd185fae40e"
+  integrity sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==
+
+acorn@^6.0.7:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.1.1.tgz#7d25ae05bb8ad1f9b699108e1094ecd7884adc1f"
+  integrity sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==
+
+ajv@^6.9.1:
+  version "6.10.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.10.0.tgz#90d0d54439da587cd7e843bfb7045f50bd22bdf1"
+  integrity sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==
+  dependencies:
+    fast-deep-equal "^2.0.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
+ansi-escapes@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
+  integrity sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==
+
+ansi-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
+  integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
+
+ansi-regex@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
+  integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
+
+ansi-styles@^3.2.0, ansi-styles@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
+  integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
+  dependencies:
+    color-convert "^1.9.0"
+
+argparse@^1.0.7:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
+  integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
+  dependencies:
+    sprintf-js "~1.0.2"
+
 array-flatten@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
   integrity sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=
+
+astral-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
+  integrity sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==
 
 aws-sdk@^2.413.0:
   version "2.413.0"
@@ -41,6 +111,11 @@ aws-sdk@^2.413.0:
     url "0.10.3"
     uuid "3.3.2"
     xml2js "0.4.19"
+
+balanced-match@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
+  integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
 base64-js@^1.0.2:
   version "1.3.0"
@@ -63,6 +138,14 @@ body-parser@1.18.3:
     raw-body "2.3.3"
     type-is "~1.6.16"
 
+brace-expansion@^1.1.7:
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
+  integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
+  dependencies:
+    balanced-match "^1.0.0"
+    concat-map "0.0.1"
+
 bson@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/bson/-/bson-1.1.0.tgz#bee57d1fb6a87713471af4e32bcae36de814b5b0"
@@ -81,6 +164,54 @@ bytes@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
   integrity sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=
+
+callsites@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
+  integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
+
+chalk@^2.0.0, chalk@^2.1.0, chalk@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
+  integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
+
+chardet@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
+  integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
+
+cli-cursor@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
+  integrity sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=
+  dependencies:
+    restore-cursor "^2.0.0"
+
+cli-width@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
+  integrity sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=
+
+color-convert@^1.9.0:
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
+  integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
+  dependencies:
+    color-name "1.1.3"
+
+color-name@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
+  integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
+
+concat-map@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
+  integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
 content-disposition@0.5.2:
   version "0.5.2"
@@ -119,12 +250,35 @@ cookies@0.7.3:
     depd "~1.1.2"
     keygrip "~1.0.3"
 
+cross-spawn@^6.0.5:
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
+  integrity sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==
+  dependencies:
+    nice-try "^1.0.4"
+    path-key "^2.0.1"
+    semver "^5.5.0"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
+
 debug@2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
   dependencies:
     ms "2.0.0"
+
+debug@^4.0.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
+  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
+  dependencies:
+    ms "^2.1.1"
+
+deep-is@~0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
+  integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
 
 depd@~1.1.2:
   version "1.1.2"
@@ -136,6 +290,13 @@ destroy@~1.0.4:
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
   integrity sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
 
+doctrine@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-3.0.0.tgz#addebead72a6574db783639dc87a121773973961"
+  integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
+  dependencies:
+    esutils "^2.0.2"
+
 dotenv@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-7.0.0.tgz#a2be3cd52736673206e8a85fb5210eea29628e7c"
@@ -145,6 +306,11 @@ ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
+
+emoji-regex@^7.0.1:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
+  integrity sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
 
 encodeurl@~1.0.2:
   version "1.0.2"
@@ -160,6 +326,109 @@ escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
+
+escape-string-regexp@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
+  integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
+
+eslint-scope@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.3.tgz#ca03833310f6889a3264781aa82e63eb9cfe7848"
+  integrity sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==
+  dependencies:
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
+
+eslint-utils@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.3.1.tgz#9a851ba89ee7c460346f97cf8939c7298827e512"
+  integrity sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==
+
+eslint-visitor-keys@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
+  integrity sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==
+
+eslint@^5.16.0:
+  version "5.16.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-5.16.0.tgz#a1e3ac1aae4a3fbd8296fcf8f7ab7314cbb6abea"
+  integrity sha512-S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    ajv "^6.9.1"
+    chalk "^2.1.0"
+    cross-spawn "^6.0.5"
+    debug "^4.0.1"
+    doctrine "^3.0.0"
+    eslint-scope "^4.0.3"
+    eslint-utils "^1.3.1"
+    eslint-visitor-keys "^1.0.0"
+    espree "^5.0.1"
+    esquery "^1.0.1"
+    esutils "^2.0.2"
+    file-entry-cache "^5.0.1"
+    functional-red-black-tree "^1.0.1"
+    glob "^7.1.2"
+    globals "^11.7.0"
+    ignore "^4.0.6"
+    import-fresh "^3.0.0"
+    imurmurhash "^0.1.4"
+    inquirer "^6.2.2"
+    js-yaml "^3.13.0"
+    json-stable-stringify-without-jsonify "^1.0.1"
+    levn "^0.3.0"
+    lodash "^4.17.11"
+    minimatch "^3.0.4"
+    mkdirp "^0.5.1"
+    natural-compare "^1.4.0"
+    optionator "^0.8.2"
+    path-is-inside "^1.0.2"
+    progress "^2.0.0"
+    regexpp "^2.0.1"
+    semver "^5.5.1"
+    strip-ansi "^4.0.0"
+    strip-json-comments "^2.0.1"
+    table "^5.2.3"
+    text-table "^0.2.0"
+
+espree@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-5.0.1.tgz#5d6526fa4fc7f0788a5cf75b15f30323e2f81f7a"
+  integrity sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==
+  dependencies:
+    acorn "^6.0.7"
+    acorn-jsx "^5.0.0"
+    eslint-visitor-keys "^1.0.0"
+
+esprima@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
+  integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
+
+esquery@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.0.1.tgz#406c51658b1f5991a5f9b62b1dc25b00e3e5c708"
+  integrity sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==
+  dependencies:
+    estraverse "^4.0.0"
+
+esrecurse@^4.1.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.2.1.tgz#007a3b9fdbc2b3bb87e4879ea19c92fdbd3942cf"
+  integrity sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==
+  dependencies:
+    estraverse "^4.1.0"
+
+estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
+  integrity sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=
+
+esutils@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
+  integrity sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=
 
 etag@~1.8.1:
   version "1.8.1"
@@ -207,6 +476,44 @@ express@^4.16.4:
     utils-merge "1.0.1"
     vary "~1.1.2"
 
+external-editor@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.0.3.tgz#5866db29a97826dbe4bf3afd24070ead9ea43a27"
+  integrity sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==
+  dependencies:
+    chardet "^0.7.0"
+    iconv-lite "^0.4.24"
+    tmp "^0.0.33"
+
+fast-deep-equal@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
+  integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
+
+fast-json-stable-stringify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
+  integrity sha1-1RQsDK7msRifh9OnYREGT4bIu/I=
+
+fast-levenshtein@~2.0.4:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
+  integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
+
+figures@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
+  integrity sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=
+  dependencies:
+    escape-string-regexp "^1.0.5"
+
+file-entry-cache@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-5.0.1.tgz#ca0f6efa6dd3d561333fb14515065c2fafdf439c"
+  integrity sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==
+  dependencies:
+    flat-cache "^2.0.1"
+
 finalhandler@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.1.1.tgz#eebf4ed840079c83f4249038c9d703008301b105"
@@ -220,6 +527,20 @@ finalhandler@1.1.1:
     statuses "~1.4.0"
     unpipe "~1.0.0"
 
+flat-cache@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-2.0.1.tgz#5d296d6f04bda44a4630a301413bdbc2ec085ec0"
+  integrity sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==
+  dependencies:
+    flatted "^2.0.0"
+    rimraf "2.6.3"
+    write "1.0.3"
+
+flatted@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.0.tgz#55122b6536ea496b4b44893ee2608141d10d9916"
+  integrity sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==
+
 forwarded@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84"
@@ -229,6 +550,38 @@ fresh@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
   integrity sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=
+
+fs.realpath@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
+  integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
+
+functional-red-black-tree@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
+  integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
+
+glob@^7.1.2, glob@^7.1.3:
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.4.tgz#aa608a2f6c577ad357e1ae5a5c26d9a8d1969255"
+  integrity sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+globals@^11.7.0:
+  version "11.12.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
+  integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
+
+has-flag@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
+  integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
 
 http-errors@1.6.3, http-errors@~1.6.2, http-errors@~1.6.3:
   version "1.6.3"
@@ -247,6 +600,13 @@ iconv-lite@0.4.23:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
+iconv-lite@^0.4.24:
+  version "0.4.24"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
+  integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3"
+
 ieee754@1.1.8:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
@@ -257,30 +617,126 @@ ieee754@^1.1.4:
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.12.tgz#50bf24e5b9c8bb98af4964c941cdb0918da7b60b"
   integrity sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA==
 
-inherits@2.0.3:
+ignore@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
+  integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
+
+import-fresh@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.0.0.tgz#a3d897f420cab0e671236897f75bc14b4885c390"
+  integrity sha512-pOnA9tfM3Uwics+SaBLCNyZZZbK+4PTu0OPZtLlMIrv17EdBoC15S9Kn8ckJ9TZTyKb3ywNE5y1yeDxxGA7nTQ==
+  dependencies:
+    parent-module "^1.0.0"
+    resolve-from "^4.0.0"
+
+imurmurhash@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
+  integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
+
+inflight@^1.0.4:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
+  integrity sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=
+  dependencies:
+    once "^1.3.0"
+    wrappy "1"
+
+inherits@2, inherits@2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
+
+inquirer@^6.2.2:
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.3.1.tgz#7a413b5e7950811013a3db491c61d1f3b776e8e7"
+  integrity sha512-MmL624rfkFt4TG9y/Jvmt8vdmOo836U7Y0Hxr2aFk3RelZEGX4Igk0KabWrcaaZaTv9uzglOqWh1Vly+FAWAXA==
+  dependencies:
+    ansi-escapes "^3.2.0"
+    chalk "^2.4.2"
+    cli-cursor "^2.1.0"
+    cli-width "^2.0.0"
+    external-editor "^3.0.3"
+    figures "^2.0.0"
+    lodash "^4.17.11"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rxjs "^6.4.0"
+    string-width "^2.1.0"
+    strip-ansi "^5.1.0"
+    through "^2.3.6"
 
 ipaddr.js@1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.8.0.tgz#eaa33d6ddd7ace8f7f6fe0c9ca0440e706738b1e"
   integrity sha1-6qM9bd16zo9/b+DJygRA5wZzix4=
 
+is-fullwidth-code-point@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
+  integrity sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=
+
+is-promise@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
+  integrity sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=
+
 isarray@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
+
+isexe@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
+  integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
 
 jmespath@0.15.0:
   version "0.15.0"
   resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"
   integrity sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=
 
+js-tokens@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
+  integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
+
+js-yaml@^3.13.0:
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
+  integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
+json-schema-traverse@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
+  integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
+
+json-stable-stringify-without-jsonify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
+  integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
+
 keygrip@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/keygrip/-/keygrip-1.0.3.tgz#399d709f0aed2bab0a059e0cdd3a5023a053e1dc"
   integrity sha512-/PpesirAIfaklxUzp4Yb7xBper9MwP6hNRA6BGGUFCgbJ+BM5CKBtsoxinNXkLHAr+GXS1/lSlF2rP7cv5Fl+g==
+
+levn@^0.3.0, levn@~0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
+  integrity sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=
+  dependencies:
+    prelude-ls "~1.1.2"
+    type-check "~0.3.2"
+
+lodash@^4.17.11:
+  version "4.17.11"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
+  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
 media-typer@0.3.0:
   version "0.3.0"
@@ -319,6 +775,30 @@ mime@1.4.1:
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.4.1.tgz#121f9ebc49e3766f311a76e1fa1c8003c4b03aa6"
   integrity sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==
 
+mimic-fn@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
+  integrity sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==
+
+minimatch@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
+  integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
+  dependencies:
+    brace-expansion "^1.1.7"
+
+minimist@0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
+  integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
+
+mkdirp@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
+  integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
+  dependencies:
+    minimist "0.0.8"
+
 mongodb-core@3.1.11:
   version "3.1.11"
   resolved "https://registry.yarnpkg.com/mongodb-core/-/mongodb-core-3.1.11.tgz#b253038dbb4d7329f3d1c2ee5400bb0c9221fde5"
@@ -343,10 +823,30 @@ ms@2.0.0:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
   integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
 
+ms@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
+  integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
+
+mute-stream@0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
+  integrity sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
+
+natural-compare@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
+  integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
+
 negotiator@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
   integrity sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=
+
+nice-try@^1.0.4:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
+  integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
 on-finished@~2.3.0:
   version "2.3.0"
@@ -360,10 +860,63 @@ on-headers@~1.0.2:
   resolved "https://registry.yarnpkg.com/on-headers/-/on-headers-1.0.2.tgz#772b0ae6aaa525c399e489adfad90c403eb3c28f"
   integrity sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==
 
+once@^1.3.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
+  integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
+  dependencies:
+    wrappy "1"
+
+onetime@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-2.0.1.tgz#067428230fd67443b2794b22bba528b6867962d4"
+  integrity sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=
+  dependencies:
+    mimic-fn "^1.0.0"
+
+optionator@^0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.2.tgz#364c5e409d3f4d6301d6c0b4c05bba50180aeb64"
+  integrity sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=
+  dependencies:
+    deep-is "~0.1.3"
+    fast-levenshtein "~2.0.4"
+    levn "~0.3.0"
+    prelude-ls "~1.1.2"
+    type-check "~0.3.2"
+    wordwrap "~1.0.0"
+
+os-tmpdir@~1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
+  integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
+
+parent-module@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
+  integrity sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==
+  dependencies:
+    callsites "^3.0.0"
+
 parseurl@~1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.2.tgz#fc289d4ed8993119460c156253262cdc8de65bf3"
   integrity sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=
+
+path-is-absolute@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
+  integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
+
+path-is-inside@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
+  integrity sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=
+
+path-key@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
+  integrity sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
 
 path-to-regexp@0.1.7:
   version "0.1.7"
@@ -374,6 +927,16 @@ perish@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/perish/-/perish-1.0.2.tgz#516eba8792bc76cdb381b69f3243d2213cc4cba3"
   integrity sha512-VWFRnVQTyKr/5THvVtwsyIAvXI0fZhhZwKK73MLfbxnsrs00yUDc+KQZ7EmX+DfAGhsysiORIkEGmp3BaOEEgw==
+
+prelude-ls@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
+  integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
+
+progress@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
+  integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
 promise-retry@^1.1.1:
   version "1.1.1"
@@ -395,6 +958,11 @@ punycode@1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
   integrity sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=
+
+punycode@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
+  integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
 qs@6.5.2:
   version "6.5.2"
@@ -421,6 +989,11 @@ raw-body@2.3.3:
     iconv-lite "0.4.23"
     unpipe "1.0.0"
 
+regexpp@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.1.tgz#8d19d31cf632482b589049f8281f93dbcba4d07f"
+  integrity sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==
+
 require_optional@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require_optional/-/require_optional-1.0.1.tgz#4cf35a4247f64ca3df8c2ef208cc494b1ca8fc2e"
@@ -434,10 +1007,44 @@ resolve-from@^2.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-2.0.0.tgz#9480ab20e94ffa1d9e80a804c7ea147611966b57"
   integrity sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=
 
+resolve-from@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
+  integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
+
+restore-cursor@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-2.0.0.tgz#9f7ee287f82fd326d4fd162923d62129eee0dfaf"
+  integrity sha1-n37ih/gv0ybU/RYpI9YhKe7g368=
+  dependencies:
+    onetime "^2.0.0"
+    signal-exit "^3.0.2"
+
 retry@^0.10.0:
   version "0.10.1"
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.10.1.tgz#e76388d217992c252750241d3d3956fed98d8ff4"
   integrity sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=
+
+rimraf@2.6.3:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
+  integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
+  dependencies:
+    glob "^7.1.3"
+
+run-async@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"
+  integrity sha1-A3GrSuC91yDUFm19/aZP96RFpsA=
+  dependencies:
+    is-promise "^2.1.0"
+
+rxjs@^6.4.0:
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.2.tgz#2e35ce815cd46d84d02a209fb4e5921e051dbec7"
+  integrity sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==
+  dependencies:
+    tslib "^1.9.0"
 
 safe-buffer@5.1.2, safe-buffer@^5.1.2:
   version "5.1.2"
@@ -470,6 +1077,11 @@ semver@^5.1.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
   integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
+
+semver@^5.5.0, semver@^5.5.1:
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.0.tgz#790a7cf6fea5459bac96110b29b60412dc8ff96b"
+  integrity sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==
 
 send@0.16.2:
   version "0.16.2"
@@ -505,12 +1117,43 @@ setprototypeof@1.1.0:
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.0.tgz#d0bd85536887b6fe7c0d818cb962d9d91c54e656"
   integrity sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==
 
+shebang-command@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
+  integrity sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=
+  dependencies:
+    shebang-regex "^1.0.0"
+
+shebang-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
+  integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
+
+signal-exit@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
+  integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
+
+slice-ansi@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-2.1.0.tgz#cacd7693461a637a5788d92a7dd4fba068e81636"
+  integrity sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==
+  dependencies:
+    ansi-styles "^3.2.0"
+    astral-regex "^1.0.0"
+    is-fullwidth-code-point "^2.0.0"
+
 sparse-bitfield@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz#ff4ae6e68656056ba4b3e792ab3334d38273ca11"
   integrity sha1-/0rm5oZWBWuks+eSqzM004JzyhE=
   dependencies:
     memory-pager "^1.0.2"
+
+sprintf-js@~1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
+  integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
 "statuses@>= 1.4.0 < 2":
   version "1.5.0"
@@ -521,6 +1164,88 @@ statuses@~1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.4.0.tgz#bb73d446da2796106efcc1b601a253d6c46bd087"
   integrity sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==
+
+string-width@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
+  integrity sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==
+  dependencies:
+    is-fullwidth-code-point "^2.0.0"
+    strip-ansi "^4.0.0"
+
+string-width@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-3.1.0.tgz#22767be21b62af1081574306f69ac51b62203961"
+  integrity sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==
+  dependencies:
+    emoji-regex "^7.0.1"
+    is-fullwidth-code-point "^2.0.0"
+    strip-ansi "^5.1.0"
+
+strip-ansi@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
+  integrity sha1-qEeQIusaw2iocTibY1JixQXuNo8=
+  dependencies:
+    ansi-regex "^3.0.0"
+
+strip-ansi@^5.1.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
+  integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
+  dependencies:
+    ansi-regex "^4.1.0"
+
+strip-json-comments@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
+  integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
+
+supports-color@^5.3.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
+  integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
+  dependencies:
+    has-flag "^3.0.0"
+
+table@^5.2.3:
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/table/-/table-5.3.3.tgz#eae560c90437331b74200e011487a33442bd28b4"
+  integrity sha512-3wUNCgdWX6PNpOe3amTTPWPuF6VGvgzjKCaO1snFj0z7Y3mUPWf5+zDtxUVGispJkDECPmR29wbzh6bVMOHbcw==
+  dependencies:
+    ajv "^6.9.1"
+    lodash "^4.17.11"
+    slice-ansi "^2.1.0"
+    string-width "^3.0.0"
+
+text-table@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
+  integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
+
+through@^2.3.6:
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
+  integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
+
+tmp@^0.0.33:
+  version "0.0.33"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
+  integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
+  dependencies:
+    os-tmpdir "~1.0.2"
+
+tslib@^1.9.0:
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
+  integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
+
+type-check@~0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
+  integrity sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=
+  dependencies:
+    prelude-ls "~1.1.2"
 
 type-is@~1.6.16:
   version "1.6.16"
@@ -534,6 +1259,13 @@ unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
   integrity sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=
+
+uri-js@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.2.2.tgz#94c540e1ff772956e2299507c010aea6c8838eb0"
+  integrity sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==
+  dependencies:
+    punycode "^2.1.0"
 
 url@0.10.3:
   version "0.10.3"
@@ -557,6 +1289,30 @@ vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
+
+which@^1.2.9:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
+  integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
+  dependencies:
+    isexe "^2.0.0"
+
+wordwrap@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
+  integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
+
+wrappy@1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+  integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
+
+write@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/write/-/write-1.0.3.tgz#0800e14523b923a387e415123c865616aae0f5c3"
+  integrity sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==
+  dependencies:
+    mkdirp "^0.5.1"
 
 xml2js@0.4.19:
   version "0.4.19"

--- a/packages/ui/.eslintrc.json
+++ b/packages/ui/.eslintrc.json
@@ -1,0 +1,40 @@
+{
+    "env": {
+        "browser": true,
+        "commonjs": true,
+        "es6": true
+    },
+    "globals": {
+        "Atomics": "readonly",
+        "SharedArrayBuffer": "readonly"
+    },
+    "parser": "babel-eslint",
+    "parserOptions": {
+        "ecmaFeatures": {
+            "jsx": true
+        },
+        "ecmaVersion": 2018,
+        "sourceType": "module"
+    },
+    "plugins": [
+        "react"
+    ],
+    "rules": {
+        "indent": [
+            "error",
+            2
+        ],
+        "linebreak-style": [
+            "error",
+            "unix"
+        ],
+        "quotes": [
+            "error",
+            "single"
+        ],
+        "semi": [
+            "error",
+            "never"
+        ]
+    }
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -32,5 +32,8 @@
     "not dead",
     "not ie <= 11",
     "not op_mini all"
-  ]
+  ],
+  "devDependencies": {
+    "eslint-plugin-react": "^7.13.0"
+  }
 }

--- a/packages/ui/src/Components/ContactUs.js
+++ b/packages/ui/src/Components/ContactUs.js
@@ -1,30 +1,30 @@
-import React, {Component} from 'react';
-import { Segment, Grid, Header, Container } from 'semantic-ui-react';
+import React, {Component} from 'react'
+import { Segment, Grid, Header, Container } from 'semantic-ui-react'
 import './Stylesheets/contact.css'
-import 'semantic-ui-css/semantic.min.css';
+import 'semantic-ui-css/semantic.min.css'
 
 export default class ContactUs extends Component {
   render () {
     return (
       <div className="outer">
-       <Grid  textAlign='center' style={{height: '102vh'}}>
-         <Grid.Column verticalAlign="middle" width={6}  className="smallGrid">
-          <Grid.Row className="smallRow"></Grid.Row>
-          <Grid.Row className="smallRow">
-          <Header as="h1" color="blue" className="con">CONTACT</Header>
-          <Header as="h1" color="blue" className="us">US</Header></Grid.Row>
-          <Grid.Row className="smallRow"></Grid.Row>
-       </Grid.Column>
+        <Grid  textAlign='center' style={{height: '102vh'}}>
+          <Grid.Column verticalAlign="middle" width={6}  className="smallGrid">
+            <Grid.Row className="smallRow"></Grid.Row>
+            <Grid.Row className="smallRow">
+              <Header as="h1" color="blue" className="con">CONTACT</Header>
+              <Header as="h1" color="blue" className="us">US</Header></Grid.Row>
+            <Grid.Row className="smallRow"></Grid.Row>
+          </Grid.Column>
 
-        <Grid.Column  width={10} className="bigGrid">
-        <Header></Header>
-         <Header verticalAlign="middle" as="h1" color="blue" className="email" >EMAIL</Header>
-         <Header as="h1" color="blue" className="address">beautifulportland@gmail.com</Header>
-         <Header as="h1" color="blue" className="email">PHONE</Header>
-         <Header as="h1" color="blue" className="address">555-555-5555</Header>
-         </Grid.Column>
-      </Grid>
-    </div>
+          <Grid.Column  width={10} className="bigGrid">
+            <Header></Header>
+            <Header verticalAlign="middle" as="h1" color="blue" className="email" >EMAIL</Header>
+            <Header as="h1" color="blue" className="address">beautifulportland@gmail.com</Header>
+            <Header as="h1" color="blue" className="email">PHONE</Header>
+            <Header as="h1" color="blue" className="address">555-555-5555</Header>
+          </Grid.Column>
+        </Grid>
+      </div>
 
 
     )

--- a/packages/ui/src/Components/Context/MyProvider.js
+++ b/packages/ui/src/Components/Context/MyProvider.js
@@ -3,22 +3,22 @@ import React, { Component } from 'react'
 export const MyContext = React.createContext()
 
 export default class MyProvider extends Component {
-	constructor(props) {
-		super(props)
-		this.state = {
-			isAuthorized: false
-		}
-	}
+  constructor(props) {
+    super(props)
+    this.state = {
+      isAuthorized: false
+    }
+  }
 
-	render() {
-		return (
-			<MyContext.Provider
-				value={{
-					state: this.state
-				}}
-			>
-				{this.props.children}
-			</MyContext.Provider>
-		)
-	}
+  render() {
+    return (
+      <MyContext.Provider
+        value={{
+          state: this.state
+        }}
+      >
+        {this.props.children}
+      </MyContext.Provider>
+    )
+  }
 }

--- a/packages/ui/src/Components/Dashboard/AddEvent.js
+++ b/packages/ui/src/Components/Dashboard/AddEvent.js
@@ -3,7 +3,7 @@ import Axios from 'axios'
 import { Header, Form, Segment, Button } from 'semantic-ui-react'
 import DatePicker from 'react-datepicker'
 import Moment from 'moment'
-import "react-datepicker/dist/react-datepicker.css"
+import 'react-datepicker/dist/react-datepicker.css'
 import '../Stylesheets/Item.css'
 
 export default class AddEvent extends Component {
@@ -11,11 +11,11 @@ export default class AddEvent extends Component {
     super(props)
     this.handleName = this.handleName.bind(this)
     this.handlePhone = this.handlePhone.bind(this)
-		this.handleSubmit = this.handleSubmit.bind(this)
+    this.handleSubmit = this.handleSubmit.bind(this)
     this.dateChanged = this.dateChanged.bind(this)
     this.timeChanged = this.timeChanged.bind(this)
     this.validateField = this.validateField.bind(this)
-		this.errorClass = this.errorClass.bind(this)
+    this.errorClass = this.errorClass.bind(this)
     this.state = {
       date: new Date(),
       time: new Date(),
@@ -28,53 +28,53 @@ export default class AddEvent extends Component {
       phoneValid: false,
       nameValid: false,
       formValid: false
-      }
     }
- /* I tried to write a catch all onChange handler and was having some issues with
+  }
+  /* I tried to write a catch all onChange handler and was having some issues with
     type errors. If there is time a refactor of indivual handlers into a generic
     would be cool.
  */
 
   /* Datepicker validates and formats date and time. Only need to check if null */
-    dateChanged(d){
-      this.setState({date: d})
-      this.validateForm()
-    }
+  dateChanged(d){
+    this.setState({date: d})
+    this.validateForm()
+  }
 
-    timeChanged(t){
-      this.setState({time: t})
-      this.validateForm()
-    }
+  timeChanged(t){
+    this.setState({time: t})
+    this.validateForm()
+  }
 
-    handleName(event) {
+  handleName(event) {
   		this.setState({coordinatorName: event.target.value })
-      this.validateField('coordinatorName', event.target.value)
-    }
+    this.validateField('coordinatorName', event.target.value)
+  }
 
-    handlePhone(event) {
+  handlePhone(event) {
   		this.setState({coordinatorPhone: event.target.value })
-      this.validateField('coordinatorPhone', event.target.value)
+    this.validateField('coordinatorPhone', event.target.value)
+  }
+
+  /* Creates obj and sends via post. Clears form */
+  handleSubmit(event) {
+    const newEvent = {
+      newDate: Moment(this.state.date).format('MM-DD-YY'),
+      newTime: Moment(this.state.time).format('h:mm a'),
+      newCoorName: this.state.coordinatorName,
+      newCoorPhone: this.state.coordinatorPhone
     }
 
- /* Creates obj and sends via post. Clears form */
-    handleSubmit(event) {
-      const newEvent = {
-        newDate: Moment(this.state.date).format('MM-DD-YY'),
-        newTime: Moment(this.state.time).format('h:mm a'),
-        newCoorName: this.state.coordinatorName,
-        newCoorPhone: this.state.coordinatorPhone
-      }
-
-      Axios.post("/api/addEvent", newEvent)
-        .then(response => {
-          console.log(response, "Add Event Submitted")
-        })
-        .catch(err => {
-          console.log(err, "Try again.")
-        })
-      this.clearForm()
-      //console.log(newEvent)
-    }
+    Axios.post('/api/addEvent', newEvent)
+      .then(response => {
+        console.log(response, 'Add Event Submitted')
+      })
+      .catch(err => {
+        console.log(err, 'Try again.')
+      })
+    this.clearForm()
+    //console.log(newEvent)
+  }
 
     clearForm = () => {
       this.setState({
@@ -98,7 +98,7 @@ export default class AddEvent extends Component {
       let nameValid = this.state.nameValid
 
       switch(fieldName) {
-        case 'coordinatorName':
+      case 'coordinatorName':
   				nameValid = value.length > 2
   				error.name = nameValid ? '' : ' ✗ Please enter a vaild Name.'
   				break
@@ -106,8 +106,8 @@ export default class AddEvent extends Component {
   				phoneValid = value.match(/^[(]?[0-9]{3}[)]?[-]?[0-9]{3}[-]?[0-9]{4}$/i)
   				error.phone = phoneValid ? '' : ' ✗ Please enter a vaild phone number.'
   				break
-        default:
-          break
+      default:
+        break
       }
 
       this.setState(
@@ -139,58 +139,58 @@ export default class AddEvent extends Component {
 
     render() {
       return (
-      <Segment>
-        <Form onSubmit={(this.handleSubmit)}>
-          <Header as="h1">Add New Event</Header>
-          <Form.Group widths='equal'>
-           <Form.Field>
-            <label>Event Date</label>
-            <DatePicker
-              dateFormat="MM-dd-yy"
-              selected={this.state.date}
-              onChange={this.dateChanged}
-            />
-          </Form.Field>
-          <Form.Field>
-            <label>Event Time</label>
-            <DatePicker
-              selected={this.state.time}
-              onChange={this.timeChanged}
-              showTimeSelect
-              showTimeSelectOnly
-              timeIntervals={30}
-              dateFormat="h:mm aa"
-              timeCaption="Time"
-            />
-          </Form.Field>
-          </Form.Group>
-          <div className={`input-wrapper ${this.errorClass(this.state.error.name)}`}>
-          <Form.Field>
-            <label>Coordinator Name</label>
-            <input placeholder='Name'
-                   value={this.state.coordinatorName}
-                   onChange={this.handleName}
-            />
-          </Form.Field>
-          <div>
-            <span>{this.state.error.name || ' ✓'}</span>
-          </div>
-          </div>
-          <div className={`input-wrapper ${this.errorClass(this.state.error.phone)}`}>
-          <Form.Field>
-            <label>Coordinator Phone</label>
-            <input placeholder="Phone"
-                   value={this.state.coordinatorPhone}
-                   onChange={this.handlePhone}
-            />
-          </Form.Field>
-          <div>
-            <span>{this.state.error.phone || ' ✓'}</span>
-          </div>
-          </div>
-          <Button color="green" disabled={!this.state.formValid} type='submit'>Add Event</Button>
-         </Form>
+        <Segment>
+          <Form onSubmit={(this.handleSubmit)}>
+            <Header as="h1">Add New Event</Header>
+            <Form.Group widths='equal'>
+              <Form.Field>
+                <label>Event Date</label>
+                <DatePicker
+                  dateFormat="MM-dd-yy"
+                  selected={this.state.date}
+                  onChange={this.dateChanged}
+                />
+              </Form.Field>
+              <Form.Field>
+                <label>Event Time</label>
+                <DatePicker
+                  selected={this.state.time}
+                  onChange={this.timeChanged}
+                  showTimeSelect
+                  showTimeSelectOnly
+                  timeIntervals={30}
+                  dateFormat="h:mm aa"
+                  timeCaption="Time"
+                />
+              </Form.Field>
+            </Form.Group>
+            <div className={`input-wrapper ${this.errorClass(this.state.error.name)}`}>
+              <Form.Field>
+                <label>Coordinator Name</label>
+                <input placeholder='Name'
+                  value={this.state.coordinatorName}
+                  onChange={this.handleName}
+                />
+              </Form.Field>
+              <div>
+                <span>{this.state.error.name || ' ✓'}</span>
+              </div>
+            </div>
+            <div className={`input-wrapper ${this.errorClass(this.state.error.phone)}`}>
+              <Form.Field>
+                <label>Coordinator Phone</label>
+                <input placeholder="Phone"
+                  value={this.state.coordinatorPhone}
+                  onChange={this.handlePhone}
+                />
+              </Form.Field>
+              <div>
+                <span>{this.state.error.phone || ' ✓'}</span>
+              </div>
+            </div>
+            <Button color="green" disabled={!this.state.formValid} type='submit'>Add Event</Button>
+          </Form>
         </Segment>
-      );
+      )
     }
-  }
+}

--- a/packages/ui/src/Components/Dashboard/DashMenu.js
+++ b/packages/ui/src/Components/Dashboard/DashMenu.js
@@ -1,13 +1,13 @@
-import React, { Component } from "react";
-import { Menu } from "semantic-ui-react";
-import { NavLink } from "react-router-dom";
+import React, { Component } from 'react'
+import { Menu } from 'semantic-ui-react'
+import { NavLink } from 'react-router-dom'
 
 export default class DashMenu extends Component {
   state = {};
   handleItemClick = (e, { name }) => this.setState({ activeItem: name });
 
   render() {
-    const activeItem = this.state;
+    const activeItem = this.state
 
     return (
       <div className="dashMenu">
@@ -17,27 +17,27 @@ export default class DashMenu extends Component {
             <Menu.Item
               name="editEventTemplate"
               as={NavLink}
-              active={activeItem === "editEventTemplate"}
+              active={activeItem === 'editEventTemplate'}
               onClick={this.handleItemClick}
-              to={"/EditEventTemplate"}
+              to={'/EditEventTemplate'}
             >
               Edit Event Template
             </Menu.Item>
             <Menu.Item
               name="addEvent"
               as={NavLink}
-              active={activeItem === "addEvent"}
+              active={activeItem === 'addEvent'}
               onClick={this.handleItemClick}
-              to={"/AddEvent"}
+              to={'/AddEvent'}
             >
               Add Event
             </Menu.Item>
             <Menu.Item
               name="viewEvents"
               as={NavLink}
-              active={activeItem === "viewEvents"}
+              active={activeItem === 'viewEvents'}
               onClick={this.handleItemClick}
-              to={"/ViewUpcomingEvents"}
+              to={'/ViewUpcomingEvents'}
             >
               View Upcoming Events
             </Menu.Item>
@@ -45,9 +45,9 @@ export default class DashMenu extends Component {
           <Menu.Item
             name="volunteerList"
             as={NavLink}
-            active={activeItem === "volunteerList"}
+            active={activeItem === 'volunteerList'}
             onClick={this.handleItemClick}
-            to={"/VolunteerList"}
+            to={'/VolunteerList'}
           >
             Volunteer List
           </Menu.Item>
@@ -56,18 +56,18 @@ export default class DashMenu extends Component {
             <Menu.Item
               name="editCarouselImages"
               as={NavLink}
-              active={activeItem === "editCarouselImages"}
+              active={activeItem === 'editCarouselImages'}
               onClick={this.handleItemClick}
-              to={"/EditImages"}
+              to={'/EditImages'}
             >
               Edit Front Page Images
             </Menu.Item>
             <Menu.Item
               name="viewAllImages"
               as={NavLink}
-              active={activeItem === "viewAllImages"}
+              active={activeItem === 'viewAllImages'}
               onClick={this.handleItemClick}
-              to={"/ViewImages"}
+              to={'/ViewImages'}
             >
               View All Images
             </Menu.Item>
@@ -77,24 +77,24 @@ export default class DashMenu extends Component {
             <Menu.Item
               name="newStory"
               as={NavLink}
-              active={activeItem === "newStory"}
+              active={activeItem === 'newStory'}
               onClick={this.handleItemClick}
-              to={"/CreateStory"}
+              to={'/CreateStory'}
             >
               Create Story
             </Menu.Item>
             <Menu.Item
               name="viewStories"
               as={NavLink}
-              active={activeItem === "viewStories"}
+              active={activeItem === 'viewStories'}
               onClick={this.handleItemClick}
-              to={"/ViewStories"}
+              to={'/ViewStories'}
             >
               View Stories
             </Menu.Item>
           </Menu.Menu>
         </Menu>
       </div>
-    );
+    )
   }
 }

--- a/packages/ui/src/Components/Dashboard/EditEvent.js
+++ b/packages/ui/src/Components/Dashboard/EditEvent.js
@@ -117,28 +117,28 @@ class EditEvent extends Component {
     let coordinator_phoneValid = this.state.coordinator_phoneValid
 
     switch (fieldName) {
-      case 'location':
-        locationValid = value.length > 2
-        errors.location = locationValid
-          ? ''
-          : ' ✗ Please enter a vaild Location.'
-        break
-      case 'coordinator':
-        coordinatorValid = value.length > 2
-        errors.coordinator = coordinatorValid
-          ? ''
-          : ' ✗ Please enter a vaild Name.'
-        break
-      case 'coordinator_phone':
-        coordinator_phoneValid = value.match(
-          /^[(]?[0-9]{3}[)]?[-]?[0-9]{3}[-]?[0-9]{4}$/i
-        )
-        errors.coordinator_phone = coordinator_phoneValid
-          ? ''
-          : ' ✗ Please enter a vaild Phone Number.'
-        break
-      default:
-        break
+    case 'location':
+      locationValid = value.length > 2
+      errors.location = locationValid
+        ? ''
+        : ' ✗ Please enter a vaild Location.'
+      break
+    case 'coordinator':
+      coordinatorValid = value.length > 2
+      errors.coordinator = coordinatorValid
+        ? ''
+        : ' ✗ Please enter a vaild Name.'
+      break
+    case 'coordinator_phone':
+      coordinator_phoneValid = value.match(
+        /^[(]?[0-9]{3}[)]?[-]?[0-9]{3}[-]?[0-9]{4}$/i
+      )
+      errors.coordinator_phone = coordinator_phoneValid
+        ? ''
+        : ' ✗ Please enter a vaild Phone Number.'
+      break
+    default:
+      break
     }
 
     this.setState(

--- a/packages/ui/src/Components/Dashboard/EventTemplate/EditEventTemplate.js
+++ b/packages/ui/src/Components/Dashboard/EventTemplate/EditEventTemplate.js
@@ -4,67 +4,67 @@ import { Header } from 'semantic-ui-react'
 import Axios from 'axios'
 
 export default class EditEventTemplate extends Component {
-    constructor(props) {
-        super(props)
+  constructor(props) {
+    super(props)
 
-        this.state = {
-            event_info: [],
-            location: '',
-            time: '',
-            max_servings: 0
-        }
-
+    this.state = {
+      event_info: [],
+      location: '',
+      time: '',
+      max_servings: 0
     }
+
+  }
 	onSubmit = data => {
-        console.log(data)
-        Axios.post("/api/editEventTemplate", data)
-        .then(response => {
-            console.log(response, "Template Submitted")
-        })
-        .catch(err => {
-            console.log(err, "Try again.")
-        })
-        window.location.reload()
-    }
-    async componentDidMount() {
-        Axios.get("/api/getEventTemplate")
-        .then(res => {
-            // console.log(res.data)
-            // console.log(res.data.event_info)
-            // console.log(res.data.location)
-            // console.log(res.data.time)
-            let tempEvent_info = JSON.parse(res.data.event_info)
-            console.log(tempEvent_info)
-            this.setState({
-                event_info: tempEvent_info,
-                location: res.data.location,
-                time: res.data.time,
-                max_servings: res.data.max_servings
-            })
-        })
-        .catch(err => {
-            console.log(err, "Error Retrieving Template Information")
-        })
-    }
+	  console.log(data)
+	  Axios.post('/api/editEventTemplate', data)
+	    .then(response => {
+	      console.log(response, 'Template Submitted')
+	    })
+	    .catch(err => {
+	      console.log(err, 'Try again.')
+	    })
+	  window.location.reload()
+	}
+	async componentDidMount() {
+	  Axios.get('/api/getEventTemplate')
+	    .then(res => {
+	      // console.log(res.data)
+	      // console.log(res.data.event_info)
+	      // console.log(res.data.location)
+	      // console.log(res.data.time)
+	      let tempEvent_info = JSON.parse(res.data.event_info)
+	      console.log(tempEvent_info)
+	      this.setState({
+	        event_info: tempEvent_info,
+	        location: res.data.location,
+	        time: res.data.time,
+	        max_servings: res.data.max_servings
+	      })
+	    })
+	    .catch(err => {
+	      console.log(err, 'Error Retrieving Template Information')
+	    })
+	}
 
-    render() {
-        return (
-            <div>
-                <Header as="h1">Edit Event Template</Header>
-                {/* <Form onSubmit={this.onSubmit}> */}
-                {this.state.event_info.map((item)=>{
-                    return(
-                        <EventTemplate
-                            key={item.name}
-                            event_info={item}
-                            location={this.state.location}
-                            time={this.state.time}
-                            max_servings={this.state.max_servings}
-                            onSubmit={this.onSubmit}
-                        />
-                    )
-                })}
-            </div>
-        )
+	render() {
+	  return (
+	    <div>
+	      <Header as="h1">Edit Event Template</Header>
+	      {/* <Form onSubmit={this.onSubmit}> */}
+	      {this.state.event_info.map((item)=>{
+	        return(
+	          <EventTemplate
+	            key={item.name}
+	            event_info={item}
+	            location={this.state.location}
+	            time={this.state.time}
+	            max_servings={this.state.max_servings}
+	            onSubmit={this.onSubmit}
+	          />
+	        )
+	      })}
+	    </div>
+	  )
 	}
 }

--- a/packages/ui/src/Components/Dashboard/EventTemplate/EventTemplate.js
+++ b/packages/ui/src/Components/Dashboard/EventTemplate/EventTemplate.js
@@ -6,153 +6,153 @@ import Moment from 'moment'
 import '../../Stylesheets/EventTemplate.css'
 
 export default class EventTemplate extends Component {
-	constructor(props) {
-		super(props)
-        this.onChange = this.onChange.bind(this)
-        this.onSubmit = this.onSubmit.bind(this)
-        this.validateField = this.validateField.bind(this)
-        this.errorClass = this.errorClass.bind(this)
-		this.state = {
-            time: props.time,
-            location: props.location,
-            max_servings : props.max_servings,
-            name: props.event_info.name,
-			max_signups : props.event_info.max_signups,
-			min_servings : props.event_info.min_servings,
-			food : props.event_info.food,
-            min_vegan : props.event_info.min_vegan,
-            errors: {
-                time: '',
-                location: '',
-                max_servings: '',
-                name: '',
-                max_signups : '',
-                min_servings : '',
-                min_vegan : ''
-            },
-            timeValid: false,
-            locationValid: false,
-            nameValid: false,
-            max_servingsValid: false,
-            max_signupsValid: false,
-            min_servingsValid: false,
-            min_veganValid: false,
-            formValid: false,
-            categoryToDelete:'',
-            open: false,
-            newTime: new Date(),
-        }
+  constructor(props) {
+    super(props)
+    this.onChange = this.onChange.bind(this)
+    this.onSubmit = this.onSubmit.bind(this)
+    this.validateField = this.validateField.bind(this)
+    this.errorClass = this.errorClass.bind(this)
+    this.state = {
+      time: props.time,
+      location: props.location,
+      max_servings : props.max_servings,
+      name: props.event_info.name,
+      max_signups : props.event_info.max_signups,
+      min_servings : props.event_info.min_servings,
+      food : props.event_info.food,
+      min_vegan : props.event_info.min_vegan,
+      errors: {
+        time: '',
+        location: '',
+        max_servings: '',
+        name: '',
+        max_signups : '',
+        min_servings : '',
+        min_vegan : ''
+      },
+      timeValid: false,
+      locationValid: false,
+      nameValid: false,
+      max_servingsValid: false,
+      max_signupsValid: false,
+      min_servingsValid: false,
+      min_veganValid: false,
+      formValid: false,
+      categoryToDelete:'',
+      open: false,
+      newTime: new Date(),
     }
+  }
 
     onSubmit = (e) => {
-        e.preventDefault()
-        this.props.onSubmit(this.state)
+      e.preventDefault()
+      this.props.onSubmit(this.state)
     }
 
     updateCheckbox = (event, data) => {
-		this.setState({ [data.name]: data.checked })
-	}
-
-	onChange = (event, data) => {
-		this.setState({ [data.name]: data.value }, () => {
-			this.validateField(data.name, data.value)
-		})
+      this.setState({ [data.name]: data.checked })
     }
 
-    timeChanged = (t) => {
-        this.setState({ newTime: t },()=>{
-            this.setState({ time: Moment(this.state.newTime).format('h:mm A')})
-        })
+	onChange = (event, data) => {
+	  this.setState({ [data.name]: data.value }, () => {
+	    this.validateField(data.name, data.value)
+	  })
 	}
 
+    timeChanged = (t) => {
+      this.setState({ newTime: t },()=>{
+        this.setState({ time: Moment(this.state.newTime).format('h:mm A')})
+      })
+    }
+
     displayDeleteModal = (event, data) => {
-		this.setState({ categoryToDelete: data.name })
-		this.openModal()
+      this.setState({ categoryToDelete: data.name })
+      this.openModal()
     }
 
     openModal = () => {
-		this.setState({ open: true })
+      this.setState({ open: true })
     }
 
     closeModal = () => {
-		this.setState({ open: false })
+      this.setState({ open: false })
     }
 
     deleteEvent = (event, data) => {
-        const deletedEventTemplate = {category: data.name}
-        console.log(deletedEventTemplate)
-        Axios.post('/api/deleteEventTemplate', deletedEventTemplate)
-			.then((response) => {
-				console.log(response, 'Deleted Event ' + data.name)
-			})
-			.catch((err) => {
-				console.log(err, 'Try again.')
-			})
-        this.closeModal()
-        window.location.reload()
-	}
+      const deletedEventTemplate = {category: data.name}
+      console.log(deletedEventTemplate)
+      Axios.post('/api/deleteEventTemplate', deletedEventTemplate)
+        .then((response) => {
+          console.log(response, 'Deleted Event ' + data.name)
+        })
+        .catch((err) => {
+          console.log(err, 'Try again.')
+        })
+      this.closeModal()
+      window.location.reload()
+    }
 
     validateField(fieldName, value) {
-        let errors = this.state.errors
-        let locationValid = this.state.locationValid
-        let nameValid = this.state.nameValid
-        let timeValid = this.state.timeValid
-        let max_servingsValid = this.state.max_servingsValid
-		let max_signupsValid = this.state.max_signupsValid
-		let min_servingsValid = this.state.min_servingsValid
-		let min_veganValid = this.state.min_veganValid
+      let errors = this.state.errors
+      let locationValid = this.state.locationValid
+      let nameValid = this.state.nameValid
+      let timeValid = this.state.timeValid
+      let max_servingsValid = this.state.max_servingsValid
+      let max_signupsValid = this.state.max_signupsValid
+      let min_servingsValid = this.state.min_servingsValid
+      let min_veganValid = this.state.min_veganValid
 
-		switch (fieldName) {
-			case 'location':
-                locationValid = value.length > 5
-				errors.location = locationValid ? '' : ' ✗ Please enter a valid location'
-				break
-			case 'name':
-                nameValid = value.length > 2
-				errors.name = nameValid ? '' : ' ✗ Please enter a valid name.'
-                break
-            case 'time':
-                timeValid = value
-				errors.time = timeValid ? '' : ' ✗ Please enter a valid time (HH:MM AM or PM).'
-                break
-            case 'max_servings':
-                max_servingsValid = value > 0
-				errors.max_servings = max_servingsValid ? '' : ' ✗ Please enter a valid number for the max servings.'
-				break
-            case 'max_signups':
-                max_signupsValid = value > 0
-				errors.max_signups = max_signupsValid ? '' : ' ✗ Please enter max signups'
-				break
-			case 'min_servings':
-                min_servingsValid = value > 0 && value <= this.props.max_servings
-				errors.min_servings = min_servingsValid ? '' : ' ✗ Please enter a valid number between 0~' + this.props.max_servings + '.'
-				break
-			case 'min_vegan':
-                min_veganValid = value < this.props.max_servings/3
-				errors.min_vegan = min_veganValid ? '' : ' ✗ Please enter min vegan.'
-				break
-			default:
-				break
-		}
+      switch (fieldName) {
+      case 'location':
+        locationValid = value.length > 5
+        errors.location = locationValid ? '' : ' ✗ Please enter a valid location'
+        break
+      case 'name':
+        nameValid = value.length > 2
+        errors.name = nameValid ? '' : ' ✗ Please enter a valid name.'
+        break
+      case 'time':
+        timeValid = value
+        errors.time = timeValid ? '' : ' ✗ Please enter a valid time (HH:MM AM or PM).'
+        break
+      case 'max_servings':
+        max_servingsValid = value > 0
+        errors.max_servings = max_servingsValid ? '' : ' ✗ Please enter a valid number for the max servings.'
+        break
+      case 'max_signups':
+        max_signupsValid = value > 0
+        errors.max_signups = max_signupsValid ? '' : ' ✗ Please enter max signups'
+        break
+      case 'min_servings':
+        min_servingsValid = value > 0 && value <= this.props.max_servings
+        errors.min_servings = min_servingsValid ? '' : ' ✗ Please enter a valid number between 0~' + this.props.max_servings + '.'
+        break
+      case 'min_vegan':
+        min_veganValid = value < this.props.max_servings/3
+        errors.min_vegan = min_veganValid ? '' : ' ✗ Please enter min vegan.'
+        break
+      default:
+        break
+      }
 
-		this.setState(
-			{
-                errors,
-                locationValid,
-                nameValid,
-                timeValid,
-                max_servingsValid,
-				max_signupsValid,
-				min_servingsValid,
-				min_veganValid,
-			},
-			this.validateForm
-		)
+      this.setState(
+        {
+          errors,
+          locationValid,
+          nameValid,
+          timeValid,
+          max_servingsValid,
+          max_signupsValid,
+          min_servingsValid,
+          min_veganValid,
+        },
+        this.validateForm
+      )
     }
 
     validateForm() {
-		this.setState({
-			formValid:
+      this.setState({
+        formValid:
                 this.state.locationValid &&
                 this.state.nameValid &&
                 this.state.timeValid &&
@@ -160,159 +160,159 @@ export default class EventTemplate extends Component {
                 this.state.max_signupsValid &&
 				this.state.min_servingsValid &&
 				this.state.min_veganValid
-		})
-	}
-
-    errorClass(error) {
-		return error.length === 0 ? '' : 'has-error'
+      })
     }
 
-	render() {
-        return (
-            <div>
-                <Segment>
-                    <Form onSubmit={this.onSubmit}>
-                    <br />
-                    <div className={`input-wrapper ${this.errorClass(this.state.errors.location)}`}>
-                        <Form.Group inline>
-                            <Form.Input
-                                name="location"
-                                value={this.state.location}
-                                onChange={this.onChange}
-                                inline
-                                label="Location"
-                            />
-                            <div>
-                                <span>{this.state.errors.location || ' ✓'}</span>
-                            </div>
-                        </Form.Group>
-                    </div>
+    errorClass(error) {
+      return error.length === 0 ? '' : 'has-error'
+    }
 
-                    <div>
-                        <Form.Group inline>
-							<label>Event Time: {this.state.time}</label>
-                        <DatePicker
-                            selected={this.state.newTime}
-                            onChange={this.timeChanged}
-                            showTimeSelect
-                            showTimeSelectOnly
-                            timeIntervals={30}
-                            dateFormat="hh:mm aa"
-                            timeCaption="Time"
-                        />
-                        </Form.Group>
-                    </div>
+    render() {
+      return (
+        <div>
+          <Segment>
+            <Form onSubmit={this.onSubmit}>
+              <br />
+              <div className={`input-wrapper ${this.errorClass(this.state.errors.location)}`}>
+                <Form.Group inline>
+                  <Form.Input
+                    name="location"
+                    value={this.state.location}
+                    onChange={this.onChange}
+                    inline
+                    label="Location"
+                  />
+                  <div>
+                    <span>{this.state.errors.location || ' ✓'}</span>
+                  </div>
+                </Form.Group>
+              </div>
 
-                    <div className={`input-wrapper ${this.errorClass(this.state.errors.max_servings)}`}>
-                        <Form.Group inline>
-                            <Form.Input
-                                name="max_servings"
-                                value={this.state.max_servings}
-                                onChange={this.onChange}
-                                inline
-                                label="Max Servings"
-                            />
-                            <div>
-                                <span>{this.state.errors.max_servings || ' ✓'}</span>
-                            </div>
-                        </Form.Group>
-                    </div>
+              <div>
+                <Form.Group inline>
+                  <label>Event Time: {this.state.time}</label>
+                  <DatePicker
+                    selected={this.state.newTime}
+                    onChange={this.timeChanged}
+                    showTimeSelect
+                    showTimeSelectOnly
+                    timeIntervals={30}
+                    dateFormat="hh:mm aa"
+                    timeCaption="Time"
+                  />
+                </Form.Group>
+              </div>
 
-                    <div className={`input-wrapper ${this.errorClass(this.state.errors.name)}`}>
-                        <Form.Group inline>
-                            <Form.Input
-                                name="name"
-                                value={this.state.name}
-                                onChange={this.onChange}
-                                inline
-                                label="Name"
-                            />
-                            <div>
-                                <span>{this.state.errors.name || ' ✓'}</span>
-                            </div>
-                        </Form.Group>
-                    </div>
+              <div className={`input-wrapper ${this.errorClass(this.state.errors.max_servings)}`}>
+                <Form.Group inline>
+                  <Form.Input
+                    name="max_servings"
+                    value={this.state.max_servings}
+                    onChange={this.onChange}
+                    inline
+                    label="Max Servings"
+                  />
+                  <div>
+                    <span>{this.state.errors.max_servings || ' ✓'}</span>
+                  </div>
+                </Form.Group>
+              </div>
 
-                    <Form.Group inline>
-                        <Form.Checkbox
-                            toggle
-                            name="food"
-                            onChange={this.updateCheckbox}
-                            checked={this.state.food}
-                            label="Food"
-                        />
-                    </Form.Group>
+              <div className={`input-wrapper ${this.errorClass(this.state.errors.name)}`}>
+                <Form.Group inline>
+                  <Form.Input
+                    name="name"
+                    value={this.state.name}
+                    onChange={this.onChange}
+                    inline
+                    label="Name"
+                  />
+                  <div>
+                    <span>{this.state.errors.name || ' ✓'}</span>
+                  </div>
+                </Form.Group>
+              </div>
 
-                    <div className={`input-wrapper ${this.errorClass(this.state.errors.max_signups)}`}>
-                        <Form.Group inline>
-                            <Form.Input
-                                name="max_signups"
-                                value={this.state.max_signups }
-                                onChange={this.onChange}
-                                inline
-                                label="Maximum Signups"
-                            />
-                            <div>
-                                <span>{this.state.errors.max_signups || ' ✓'}</span>
-                            </div>
-                        </Form.Group>
-                    </div>
+              <Form.Group inline>
+                <Form.Checkbox
+                  toggle
+                  name="food"
+                  onChange={this.updateCheckbox}
+                  checked={this.state.food}
+                  label="Food"
+                />
+              </Form.Group>
 
-                    <div className={`input-wrapper ${this.errorClass(this.state.errors.min_servings)}`}>
-                        <Form.Group inline>
-                            <Form.Input
-                                name="min_servings"
-                                value={this.state.min_servings }
-                                onChange={this.onChange}
-                                inline
-                                label="Minimum Servings"
-                            />
-                            <div>
-                                <span>{this.state.errors.min_servings || ' ✓'}</span>
-                            </div>
-                        </Form.Group>
-                    </div>
+              <div className={`input-wrapper ${this.errorClass(this.state.errors.max_signups)}`}>
+                <Form.Group inline>
+                  <Form.Input
+                    name="max_signups"
+                    value={this.state.max_signups }
+                    onChange={this.onChange}
+                    inline
+                    label="Maximum Signups"
+                  />
+                  <div>
+                    <span>{this.state.errors.max_signups || ' ✓'}</span>
+                  </div>
+                </Form.Group>
+              </div>
 
-                    <div className={`input-wrapper ${this.errorClass(this.state.errors.min_vegan)}`}>
-                        <Form.Group inline>
-                            <Form.Input
-                                name="min_vegan"
-                                value={this.state.min_vegan }
-                                onChange={this.onChange}
-                                inline
-                                label="Minimum Vegan"
-                            />
-                            <div>
-                                <span>{this.state.errors.min_vegan || ' ✓'}</span>
-                            </div>
-                        </Form.Group>
-                    </div>
-                    <br />
-                    <Button color="green" /*disabled={!this.state.formValid}*/>
+              <div className={`input-wrapper ${this.errorClass(this.state.errors.min_servings)}`}>
+                <Form.Group inline>
+                  <Form.Input
+                    name="min_servings"
+                    value={this.state.min_servings }
+                    onChange={this.onChange}
+                    inline
+                    label="Minimum Servings"
+                  />
+                  <div>
+                    <span>{this.state.errors.min_servings || ' ✓'}</span>
+                  </div>
+                </Form.Group>
+              </div>
+
+              <div className={`input-wrapper ${this.errorClass(this.state.errors.min_vegan)}`}>
+                <Form.Group inline>
+                  <Form.Input
+                    name="min_vegan"
+                    value={this.state.min_vegan }
+                    onChange={this.onChange}
+                    inline
+                    label="Minimum Vegan"
+                  />
+                  <div>
+                    <span>{this.state.errors.min_vegan || ' ✓'}</span>
+                  </div>
+                </Form.Group>
+              </div>
+              <br />
+              <Button color="green" /*disabled={!this.state.formValid}*/>
                         Apply Changes
-                    </Button>
-                    </Form>
-                    <br />
-                    <Button negative onClick={this.displayDeleteModal} name={this.state.name}>
+              </Button>
+            </Form>
+            <br />
+            <Button negative onClick={this.displayDeleteModal} name={this.state.name}>
                         Delete
-                    </Button>
-                </Segment>
-                <Modal open={this.state.open} onClose={this.closeModal} closeIcon>
-                    <Header icon="calendar alternate outline" content="Delete Template" />
-                    <Modal.Content>
-                        <h3>Are you sure you want to delete [{this.state.name}] template?</h3>
-                    </Modal.Content>
-                    <Modal.Actions>
-                        <Button color="red" onClick={this.closeModal}>
-                            <Icon name="remove" /> No
-                        </Button>
-                        <Button color="green" onClick={this.deleteEvent} name={this.state.categoryToDelete}>
-                            <Icon name="checkmark" /> Yes
-                        </Button>
-                    </Modal.Actions>
-                </Modal>
-                <br />
-            </div>
-        )
+            </Button>
+          </Segment>
+          <Modal open={this.state.open} onClose={this.closeModal} closeIcon>
+            <Header icon="calendar alternate outline" content="Delete Template" />
+            <Modal.Content>
+              <h3>Are you sure you want to delete [{this.state.name}] template?</h3>
+            </Modal.Content>
+            <Modal.Actions>
+              <Button color="red" onClick={this.closeModal}>
+                <Icon name="remove" /> No
+              </Button>
+              <Button color="green" onClick={this.deleteEvent} name={this.state.categoryToDelete}>
+                <Icon name="checkmark" /> Yes
+              </Button>
+            </Modal.Actions>
+          </Modal>
+          <br />
+        </div>
+      )
     }
 }

--- a/packages/ui/src/Components/Dashboard/Images/EditCarouselImages.js
+++ b/packages/ui/src/Components/Dashboard/Images/EditCarouselImages.js
@@ -4,11 +4,11 @@ import Axios from 'axios'
 
 export default class EditCarouselImages extends Component {
     state = {
-        images: [],
-        imagesNotOnFrontPage: [],
-        removeModalOpen: false,
-        addNewModalOpen: false,
-        addFromUploadModalOpen: false,
+      images: [],
+      imagesNotOnFrontPage: [],
+      removeModalOpen: false,
+      addNewModalOpen: false,
+      addFromUploadModalOpen: false,
     }
 
     // Modal remove functions
@@ -25,315 +25,315 @@ export default class EditCarouselImages extends Component {
 
     // Serve images
     componentDidMount = () => {
-        // Images from s3 container
-        this.initializeImages()
-        // Get images specifically NOT being displayed on the front page
-       this.initializeNotFrontImages()
+      // Images from s3 container
+      this.initializeImages()
+      // Get images specifically NOT being displayed on the front page
+      this.initializeNotFrontImages()
     }
 
     // Remove images from storage and unmount
     componentWillUnmount = () => {
-        this.setState({
-            images: [],
-            imagesNotOnFrontPAge: []
-        })
+      this.setState({
+        images: [],
+        imagesNotOnFrontPAge: []
+      })
     }
 
     // Initialize images to display
     initializeImages = () => {
-        console.log("initializeImages")
-        let urls = []
-        Axios.get('/api/getImages/', {
-            params: {
-                isFrontPage: true,
-                needNotOnFront: false
-            }
-        })
+      console.log('initializeImages')
+      let urls = []
+      Axios.get('/api/getImages/', {
+        params: {
+          isFrontPage: true,
+          needNotOnFront: false
+        }
+      })
         .then((res) => {
-            urls = res.data
-            console.log(urls)
-            let imagesToDisplay = []
-            urls.forEach(url => {
-                let newImage = {
-                    imageUrl: url,
-                    checked: false
-                }
-                imagesToDisplay.push(newImage)
-            })
-            this.setState({
-                images: imagesToDisplay,
-            })
+          urls = res.data
+          console.log(urls)
+          let imagesToDisplay = []
+          urls.forEach(url => {
+            let newImage = {
+              imageUrl: url,
+              checked: false
+            }
+            imagesToDisplay.push(newImage)
+          })
+          this.setState({
+            images: imagesToDisplay,
+          })
         })
         .catch((err) => {
-            // handle error
-            console.log(err)
+          // handle error
+          console.log(err)
         })
     }
 
     // Initialize images not on front page
     initializeNotFrontImages = () => {
-        console.log("initializeNotImages")
-        Axios.get('/api/getImages/', {
-            params: {
-                isFrontPage: true,
-                needNotOnFront: true
-            }
-        })
+      console.log('initializeNotImages')
+      Axios.get('/api/getImages/', {
+        params: {
+          isFrontPage: true,
+          needNotOnFront: true
+        }
+      })
         .then((res) => {
-            let urls = res.data
-            let imagesToDisplay = []
-            if(urls.length === 0) {
-                this.setState({
-                    imagesNotOnFrontPage: []
-                })
-            }
-            else {
-                console.log(urls)
-                urls.forEach(url => {
-                    let newImage = {
-                        imageUrl: url,
-                        checked: false
-                    }
-                    imagesToDisplay.push(newImage)
-                })
-                this.setState({
-                    imagesNotOnFrontPage: imagesToDisplay,
-                })
-            }
+          let urls = res.data
+          let imagesToDisplay = []
+          if(urls.length === 0) {
+            this.setState({
+              imagesNotOnFrontPage: []
+            })
+          }
+          else {
+            console.log(urls)
+            urls.forEach(url => {
+              let newImage = {
+                imageUrl: url,
+                checked: false
+              }
+              imagesToDisplay.push(newImage)
+            })
+            this.setState({
+              imagesNotOnFrontPage: imagesToDisplay,
+            })
+          }
         })
         .catch((err) => {
-            // handle error
-            console.log(err)
+          // handle error
+          console.log(err)
         })
     }
 
     // Handles clicking a photo in the photoview
     // When photo is clicked, flip boolean
     handlePhotoClick = (item) => {
-        let tempImages = [...this.state.images]
-        let index = tempImages.indexOf(item)
-        let isClicked = tempImages[index].checked 
-        isClicked = isClicked ? false : true
-        tempImages[index].checked = isClicked
-        this.setState({
-            images: tempImages
-        })
+      let tempImages = [...this.state.images]
+      let index = tempImages.indexOf(item)
+      let isClicked = tempImages[index].checked 
+      isClicked = isClicked ? false : true
+      tempImages[index].checked = isClicked
+      this.setState({
+        images: tempImages
+      })
     }
 
     // Handles clicking a photo in the "Add from Uploaded" modal
     handlePhotoClickInModal = (item) => {
-        let tempImages = [...this.state.imagesNotOnFrontPage]
-        let index = tempImages.indexOf(item)
-        let isClicked = tempImages[index].checked 
-        isClicked = isClicked ? false : true
-        tempImages[index].checked = isClicked
-        this.setState({
-            imagesNotOnFrontPage: tempImages
-        })
+      let tempImages = [...this.state.imagesNotOnFrontPage]
+      let index = tempImages.indexOf(item)
+      let isClicked = tempImages[index].checked 
+      isClicked = isClicked ? false : true
+      tempImages[index].checked = isClicked
+      this.setState({
+        imagesNotOnFrontPage: tempImages
+      })
     }
 
     // Adding photos to s3 bucket
     addPhotos = (input) => {
-        if(input.files.length > 0) {
-            for(let i = 0; i < input.files.length; ++i) {
-                let reader = new FileReader()
-                reader.onerror = () => {
-                    reader.abort()
-                    console.log("Problem parsing input file")
-                }
-                reader.onload = e => {
-                    let data = e.target.result
-                    let file = {
-                        "fileData": data,
-                        "fileName": input.files[i].name
-                    }
-                    Axios.post('/api/addImagesToBucket', {
-                        filesToAdd: file,
-                        isFrontPage: true
-                    })
-                    .then(res => {
-                        if(i === (input.files.length - 1)) {
-                            this.initializeImages()
-                            this.setState({
-                                addNewModalOpen: false
-                            })
-                        }
-                    })
-                    .catch(err => {
-                        console.log(err)
-                    })
-                }
-                reader.readAsDataURL(input.files[i])
+      if(input.files.length > 0) {
+        for(let i = 0; i < input.files.length; ++i) {
+          let reader = new FileReader()
+          reader.onerror = () => {
+            reader.abort()
+            console.log('Problem parsing input file')
+          }
+          reader.onload = e => {
+            let data = e.target.result
+            let file = {
+              'fileData': data,
+              'fileName': input.files[i].name
             }
+            Axios.post('/api/addImagesToBucket', {
+              filesToAdd: file,
+              isFrontPage: true
+            })
+              .then(res => {
+                if(i === (input.files.length - 1)) {
+                  this.initializeImages()
+                  this.setState({
+                    addNewModalOpen: false
+                  })
+                }
+              })
+              .catch(err => {
+                console.log(err)
+              })
+          }
+          reader.readAsDataURL(input.files[i])
         }
+      }
     }
 
     // Removing photos
     // Parses through to remove multiple. If one or
     // more images to remove, send API call to backend
     removePhotosFromFrontPage = () => {
-        let imagesToDelete = []
-        let tempImages = [...this.state.images]
-        tempImages = tempImages.filter(image => {
-            if(image.checked === true){
-                imagesToDelete.push(image.imageUrl)
-                return false
-            }
-            else {
-                return true
-            }
-        })
-        this.setState({
-            images: tempImages,
-            removeModalOpen: false
-        })
-        if(imagesToDelete.length > 0) {
-            Axios.post('/api/removeImagesFromFrontPage', {
-                urlsToRemove: imagesToDelete,
-            })
-            .then(res => {
-                console.log(res)
-            })
-            .catch(err => {
-                console.log(err)
-            })
-            this.initializeNotFrontImages()
+      let imagesToDelete = []
+      let tempImages = [...this.state.images]
+      tempImages = tempImages.filter(image => {
+        if(image.checked === true){
+          imagesToDelete.push(image.imageUrl)
+          return false
         }
+        else {
+          return true
+        }
+      })
+      this.setState({
+        images: tempImages,
+        removeModalOpen: false
+      })
+      if(imagesToDelete.length > 0) {
+        Axios.post('/api/removeImagesFromFrontPage', {
+          urlsToRemove: imagesToDelete,
+        })
+          .then(res => {
+            console.log(res)
+          })
+          .catch(err => {
+            console.log(err)
+          })
+        this.initializeNotFrontImages()
+      }
     }
 
     // Add photos to s3 from already uploaded photos
     addPhotosFromUploaded = () => {
-        let imagesToDelete = []
-        let tempImages = [...this.state.imagesNotOnFrontPage]
-        tempImages = tempImages.filter(image => {
-            if(image.checked === true){
-                imagesToDelete.push(image.imageUrl)
-                return false
-            }
-            else {
-                return true
-            }
-        })
-        console.log(tempImages)
-        this.setState({
-            imagesNotOnFrontPage: tempImages,
-            addFromUploadModalOpen: false
-        })
-        if(imagesToDelete.length > 0) {
-            Axios.post('/api/addImageFromUploaded', {
-                urlsToRemove: imagesToDelete
-            })
-            .then(res => {
-                console.log(res)
-            })
-            .catch(err => {
-                console.log(err)
-            })
-            this.initializeImages()
+      let imagesToDelete = []
+      let tempImages = [...this.state.imagesNotOnFrontPage]
+      tempImages = tempImages.filter(image => {
+        if(image.checked === true){
+          imagesToDelete.push(image.imageUrl)
+          return false
         }
+        else {
+          return true
+        }
+      })
+      console.log(tempImages)
+      this.setState({
+        imagesNotOnFrontPage: tempImages,
+        addFromUploadModalOpen: false
+      })
+      if(imagesToDelete.length > 0) {
+        Axios.post('/api/addImageFromUploaded', {
+          urlsToRemove: imagesToDelete
+        })
+          .then(res => {
+            console.log(res)
+          })
+          .catch(err => {
+            console.log(err)
+          })
+        this.initializeImages()
+      }
     }
 
     render() {
-        return (
-            <div className="photoView">
-                <Modal  trigger= {
-                        <Button className='addNewPhotos' icon labelPosition='left' size="medium" onClick={this.handleAddModalOpen}>
-                            <Icon name='add' />
+      return (
+        <div className="photoView">
+          <Modal  trigger= {
+            <Button className='addNewPhotos' icon labelPosition='left' size="medium" onClick={this.handleAddModalOpen}>
+              <Icon name='add' />
                             Add New Photos
-                        </Button>
-                        }
-                        open= {this.state.addNewModalOpen}
-                        onClose={this.handleAddModalClose}
-                    >
-                    <Modal.Content>
-                        <h3> Add photos </h3>
-                        <Form>
-                            <input type='file' id="files" name="files[]" multiple></input>
-                        </Form>
-                    </Modal.Content>
-                    <Modal.Actions>
-                        <Button color='red' inverted onClick={this.handleAddModalClose}>
-                            <Icon name='remove' /> 
+            </Button>
+          }
+          open= {this.state.addNewModalOpen}
+          onClose={this.handleAddModalClose}
+          >
+            <Modal.Content>
+              <h3> Add photos </h3>
+              <Form>
+                <input type='file' id="files" name="files[]" multiple></input>
+              </Form>
+            </Modal.Content>
+            <Modal.Actions>
+              <Button color='red' inverted onClick={this.handleAddModalClose}>
+                <Icon name='remove' /> 
                             Cancel
-                        </Button>
-                        <Button color='green' inverted onClick={e => this.addPhotos(document.getElementById("files"))}>
-                            <Icon name='checkmark' /> 
+              </Button>
+              <Button color='green' inverted onClick={e => this.addPhotos(document.getElementById('files'))}>
+                <Icon name='checkmark' /> 
                             Upload Photo
-                        </Button>
-                    </Modal.Actions> 
-                </Modal>
-                <Modal  trigger= {
-                        <Button className='addFromUploaded' icon labelPosition='left' size="medium" onClick={this.handleAddFromModalOpen}>
-                            <Icon name='add' />
+              </Button>
+            </Modal.Actions> 
+          </Modal>
+          <Modal  trigger= {
+            <Button className='addFromUploaded' icon labelPosition='left' size="medium" onClick={this.handleAddFromModalOpen}>
+              <Icon name='add' />
                             Add Photos From Uploaded
-                        </Button>
-                        }
-                        open= {this.state.addFromUploadModalOpen}
-                        onClose={this.handleAddFromModalClose}
-                    >
-                    <Modal.Content>
-                        <h3> Choose Photos </h3>
-                        <Card.Group className="cardGroup" itemsPerRow = {5}>
-                            {
-                                this.state.imagesNotOnFrontPage.length > 0 && this.state.imagesNotOnFrontPage.map(item => (
-                                    <Card 
-                                        image={item.imageUrl} 
-                                        onClick={e => {this.handlePhotoClickInModal(item)}}
-                                        className={item.checked ? 'clicked' : 'notClicked'} 
-                                    />
-                                ))
-                            }
-                        </Card.Group>       
-                    </Modal.Content>
-                    <Modal.Actions>
-                        <Button color='red' inverted onClick={this.handleAddFromModalClose}>
-                            <Icon name='remove' /> 
+            </Button>
+          }
+          open= {this.state.addFromUploadModalOpen}
+          onClose={this.handleAddFromModalClose}
+          >
+            <Modal.Content>
+              <h3> Choose Photos </h3>
+              <Card.Group className="cardGroup" itemsPerRow = {5}>
+                {
+                  this.state.imagesNotOnFrontPage.length > 0 && this.state.imagesNotOnFrontPage.map(item => (
+                    <Card 
+                      image={item.imageUrl} 
+                      onClick={e => {this.handlePhotoClickInModal(item)}}
+                      className={item.checked ? 'clicked' : 'notClicked'} 
+                    />
+                  ))
+                }
+              </Card.Group>       
+            </Modal.Content>
+            <Modal.Actions>
+              <Button color='red' inverted onClick={this.handleAddFromModalClose}>
+                <Icon name='remove' /> 
                             Cancel
-                        </Button>
-                        <Button color='green' inverted onClick={this.addPhotosFromUploaded}>
-                            <Icon name='checkmark' /> 
+              </Button>
+              <Button color='green' inverted onClick={this.addPhotosFromUploaded}>
+                <Icon name='checkmark' /> 
                             Add Photos
-                        </Button>
-                    </Modal.Actions> 
-                </Modal>
-                <Modal  trigger={
-                            <Button className='deletePhotos' icon labelPosition='left' size="medium" onClick={this.handleOpen}>
-                                <Icon name='trash' />
+              </Button>
+            </Modal.Actions> 
+          </Modal>
+          <Modal  trigger={
+            <Button className='deletePhotos' icon labelPosition='left' size="medium" onClick={this.handleOpen}>
+              <Icon name='trash' />
                                 Remove Photos from Front Page
-                            </Button>
-                        } 
-                        open={this.state.removeModalOpen}
-                        onClose={this.handleClose}
-                        basic 
-                        size='small'
-                >
-                    <Header icon='trash' content='Remove Photos' />
-                    <Modal.Content>
-                        <p>
+            </Button>
+          } 
+          open={this.state.removeModalOpen}
+          onClose={this.handleClose}
+          basic 
+          size='small'
+          >
+            <Header icon='trash' content='Remove Photos' />
+            <Modal.Content>
+              <p>
                             Are you sure you want to remove these photos from the front page?
-                        </p>
-                    </Modal.Content>
-                    <Modal.Actions>
-                        <Button basic color='red' inverted onClick={this.handleClose}>
-                            <Icon name='remove' /> No
-                        </Button>
-                        <Button color='green' inverted onClick={this.removePhotosFromFrontPage}>
-                            <Icon name='checkmark' /> Yes
-                        </Button>
-                    </Modal.Actions>
-                </Modal>
-                <Card.Group className="cardGroup" itemsPerRow = {5}>
-                    {
-                        this.state.images.length > 0 && this.state.images.map(item => (
-                            <Card 
-                                image={item.imageUrl} 
-                                onClick={e => {this.handlePhotoClick(item)}}
-                                className={item.checked ? 'clicked' : 'notClicked'} 
-                            />
-                        ))
-                    }
-                </Card.Group>
-            </div>
-        )
+              </p>
+            </Modal.Content>
+            <Modal.Actions>
+              <Button basic color='red' inverted onClick={this.handleClose}>
+                <Icon name='remove' /> No
+              </Button>
+              <Button color='green' inverted onClick={this.removePhotosFromFrontPage}>
+                <Icon name='checkmark' /> Yes
+              </Button>
+            </Modal.Actions>
+          </Modal>
+          <Card.Group className="cardGroup" itemsPerRow = {5}>
+            {
+              this.state.images.length > 0 && this.state.images.map(item => (
+                <Card 
+                  image={item.imageUrl} 
+                  onClick={e => {this.handlePhotoClick(item)}}
+                  className={item.checked ? 'clicked' : 'notClicked'} 
+                />
+              ))
+            }
+          </Card.Group>
+        </div>
+      )
     }
 }

--- a/packages/ui/src/Components/Dashboard/Images/ViewAllImages.js
+++ b/packages/ui/src/Components/Dashboard/Images/ViewAllImages.js
@@ -5,9 +5,9 @@ import '../../Stylesheets/ViewAllImages.css'
 
 export default class ViewAllImages extends Component {
     state = {
-        images: [],
-        modalOpen: false,
-        addModalOpen: false
+      images: [],
+      modalOpen: false,
+      addModalOpen: false
     }
 
     // Modal remove functions
@@ -20,194 +20,194 @@ export default class ViewAllImages extends Component {
 
     // Serve images
     componentDidMount = () => {
-        // Images from s3 container
-        this.initializeImages()
+      // Images from s3 container
+      this.initializeImages()
     }
 
     // Remove images (unmount)
     componentWillUnmount = () => {
-        this.setState({
-            images: []
-        })
+      this.setState({
+        images: []
+      })
     }
 
     // Get all images from s3 bucket and display
     initializeImages = () => {
-        let urls = []
-        Axios.get('/api/getImages/', {
-            params: {
-                isFrontPage: false,
-                needNotOnFront: false
-            }
-        })
+      let urls = []
+      Axios.get('/api/getImages/', {
+        params: {
+          isFrontPage: false,
+          needNotOnFront: false
+        }
+      })
         .then((res) => {
-            urls = res.data
-            let imagesToDisplay = []
-            urls.forEach(url => {
-                let newImage = {
-                    imageUrl: url,
-                    checked: false
-                }
-                imagesToDisplay.push(newImage)
-            })
-            this.setState({
-                images: imagesToDisplay,
-            })
+          urls = res.data
+          let imagesToDisplay = []
+          urls.forEach(url => {
+            let newImage = {
+              imageUrl: url,
+              checked: false
+            }
+            imagesToDisplay.push(newImage)
+          })
+          this.setState({
+            images: imagesToDisplay,
+          })
         })
         .catch((err) => {
-            // handle error
-            console.log(err)
+          // handle error
+          console.log(err)
         })
     }
 
     // When photo is clicked, flip boolean
     handlePhotoClick = (item) => {
-        let tempImages = [...this.state.images]
-        let index = tempImages.indexOf(item)
-        let isClicked = tempImages[index].checked 
-        isClicked = isClicked ? false : true
-        tempImages[index].checked = isClicked
-        this.setState({
-            images: tempImages
-        })
+      let tempImages = [...this.state.images]
+      let index = tempImages.indexOf(item)
+      let isClicked = tempImages[index].checked 
+      isClicked = isClicked ? false : true
+      tempImages[index].checked = isClicked
+      this.setState({
+        images: tempImages
+      })
     }
 
     // Adding photos to s3 bucket
     addPhotos = (input) => {
-        if(input.files.length > 0) {
-            for(let i = 0; i < input.files.length; ++i) {
-                let reader = new FileReader()
-                reader.onerror = () => {
-                    reader.abort()
-                    console.log("Problem parsing input file")
-                }
-                reader.onload = e => {
-                    let data = e.target.result
-                    let file = {
-                        "fileData": data,
-                        "fileName": input.files[i].name
-                    }
-                    Axios.post('/api/addImagesToBucket', {
-                        filesToAdd: file,
-                        isFrontPage: false
-                    })
-                    .then(res => {
-                        if(i === (input.files.length - 1)) {
-                            this.initializeImages()
-                            this.setState({
-                                addModalOpen: false
-                            })
-                        }
-                    })
-                    .catch(err => {
-                        console.log(err)
-                    })
-                }
-                reader.readAsDataURL(input.files[i])
+      if(input.files.length > 0) {
+        for(let i = 0; i < input.files.length; ++i) {
+          let reader = new FileReader()
+          reader.onerror = () => {
+            reader.abort()
+            console.log('Problem parsing input file')
+          }
+          reader.onload = e => {
+            let data = e.target.result
+            let file = {
+              'fileData': data,
+              'fileName': input.files[i].name
             }
+            Axios.post('/api/addImagesToBucket', {
+              filesToAdd: file,
+              isFrontPage: false
+            })
+              .then(res => {
+                if(i === (input.files.length - 1)) {
+                  this.initializeImages()
+                  this.setState({
+                    addModalOpen: false
+                  })
+                }
+              })
+              .catch(err => {
+                console.log(err)
+              })
+          }
+          reader.readAsDataURL(input.files[i])
         }
+      }
     }
 
     // Removing photos
     // Parses through to remove multiple. If one or
     // more images to remove, send API call to backend
     removePhotos = () => {
-        let imagesToDelete = []
-        let tempImages = [...this.state.images]
-        tempImages = tempImages.filter(image => {
-            if(image.checked === true){
-                imagesToDelete.push(image.imageUrl)
-                return false
-            }
-            else {
-                return true
-            }
-        })
-        this.setState({
-            images: tempImages,
-            modalOpen: false
-        })
-        if(imagesToDelete.length > 0) {
-            Axios.post('/api/removeImageFromBucket', {
-                urlsToRemove: imagesToDelete,
-                isFrontPage: false
-            })
-            .then(res => {
-                console.log(res)
-            })
-            .catch(err => {
-                console.log(err)
-            })
+      let imagesToDelete = []
+      let tempImages = [...this.state.images]
+      tempImages = tempImages.filter(image => {
+        if(image.checked === true){
+          imagesToDelete.push(image.imageUrl)
+          return false
         }
+        else {
+          return true
+        }
+      })
+      this.setState({
+        images: tempImages,
+        modalOpen: false
+      })
+      if(imagesToDelete.length > 0) {
+        Axios.post('/api/removeImageFromBucket', {
+          urlsToRemove: imagesToDelete,
+          isFrontPage: false
+        })
+          .then(res => {
+            console.log(res)
+          })
+          .catch(err => {
+            console.log(err)
+          })
+      }
     }
 
     render() {
-        return (
-            <div className="photoView">
-                <Modal  trigger= {
-                        <Button className='addPhotos' icon labelPosition='left' size="medium" onClick={this.handleAddModalOpen}>
-                            <Icon name='add' />
+      return (
+        <div className="photoView">
+          <Modal  trigger= {
+            <Button className='addPhotos' icon labelPosition='left' size="medium" onClick={this.handleAddModalOpen}>
+              <Icon name='add' />
                             Add Photos
-                        </Button>
-                        }
-                        open= {this.state.addModalOpen}
-                        onClose={this.handleAddModalClose}
-                    >
-                    <Modal.Content>
-                        <h3> Add photos </h3>
-                        <Form>
-                            <input type='file' id="files" name="files[]" multiple></input>
-                        </Form>
-                    </Modal.Content>
-                    <Modal.Actions>
-                        <Button color='red' inverted onClick={this.handleAddModalClose}>
-                            <Icon name='remove' /> 
+            </Button>
+          }
+          open= {this.state.addModalOpen}
+          onClose={this.handleAddModalClose}
+          >
+            <Modal.Content>
+              <h3> Add photos </h3>
+              <Form>
+                <input type='file' id="files" name="files[]" multiple></input>
+              </Form>
+            </Modal.Content>
+            <Modal.Actions>
+              <Button color='red' inverted onClick={this.handleAddModalClose}>
+                <Icon name='remove' /> 
                             Cancel
-                        </Button>
-                        <Button color='green' inverted onClick={e => this.addPhotos(document.getElementById("files"))}>
-                            <Icon name='checkmark' /> 
+              </Button>
+              <Button color='green' inverted onClick={e => this.addPhotos(document.getElementById('files'))}>
+                <Icon name='checkmark' /> 
                             Upload
-                        </Button>
-                    </Modal.Actions> 
-                </Modal>
-                <Modal  trigger={
-                            <Button className='deletePhotos' icon labelPosition='left' size="medium" onClick={this.handleOpen}>
-                                <Icon name='trash' />
+              </Button>
+            </Modal.Actions> 
+          </Modal>
+          <Modal  trigger={
+            <Button className='deletePhotos' icon labelPosition='left' size="medium" onClick={this.handleOpen}>
+              <Icon name='trash' />
                                 Remove Photos
-                            </Button>
-                        } 
-                        open={this.state.modalOpen}
-                        onClose={this.handleClose}
-                        basic 
-                        size='small'
-                >
-                    <Header icon='trash' content='Remove Photos' />
-                    <Modal.Content>
-                        <p>
+            </Button>
+          } 
+          open={this.state.modalOpen}
+          onClose={this.handleClose}
+          basic 
+          size='small'
+          >
+            <Header icon='trash' content='Remove Photos' />
+            <Modal.Content>
+              <p>
                             Are you sure you want to remove these photos?
-                        </p>
-                    </Modal.Content>
-                    <Modal.Actions>
-                        <Button basic color='red' inverted onClick={this.handleClose}>
-                            <Icon name='remove' /> No
-                        </Button>
-                        <Button color='green' inverted onClick={this.removePhotos}>
-                            <Icon name='checkmark' /> Yes
-                        </Button>
-                    </Modal.Actions>
-                </Modal>
-                <Card.Group className="cardGroup" itemsPerRow = {5}>
-                    {
-                        this.state.images.length > 0 && this.state.images.map(item => (
-                            <Card 
-                                image={item.imageUrl} 
-                                onClick={e => {this.handlePhotoClick(item)}}
-                                className={item.checked ? 'clicked' : 'notClicked'} 
-                            />
-                        ))
-                    }
-                </Card.Group>
-            </div>
-        )
+              </p>
+            </Modal.Content>
+            <Modal.Actions>
+              <Button basic color='red' inverted onClick={this.handleClose}>
+                <Icon name='remove' /> No
+              </Button>
+              <Button color='green' inverted onClick={this.removePhotos}>
+                <Icon name='checkmark' /> Yes
+              </Button>
+            </Modal.Actions>
+          </Modal>
+          <Card.Group className="cardGroup" itemsPerRow = {5}>
+            {
+              this.state.images.length > 0 && this.state.images.map(item => (
+                <Card 
+                  image={item.imageUrl} 
+                  onClick={e => {this.handlePhotoClick(item)}}
+                  className={item.checked ? 'clicked' : 'notClicked'} 
+                />
+              ))
+            }
+          </Card.Group>
+        </div>
+      )
     }
 }

--- a/packages/ui/src/Components/Dashboard/Login.js
+++ b/packages/ui/src/Components/Dashboard/Login.js
@@ -5,14 +5,14 @@ require ('dotenv').config()
 export default class Login extends Component {
   render() {
 	  	let callbackHost = process.env.REACT_APP_API_ENDPOINT || ''
-		return (
-			<div style={{position:"absolute",top:"50%",left:"40%"}}>
-				<Container>
-					<a href={`${callbackHost}/auth/google`} style={{color:"white"}}>
-						<Button size='massive' color='google plus'><Icon name='google' />Admin Login</Button>
-					</a>
-				</Container>
-			</div>
-		)
-	}
+    return (
+      <div style={{position:'absolute',top:'50%',left:'40%'}}>
+        <Container>
+          <a href={`${callbackHost}/auth/google`} style={{color:'white'}}>
+            <Button size='massive' color='google plus'><Icon name='google' />Admin Login</Button>
+          </a>
+        </Container>
+      </div>
+    )
+  }
 }

--- a/packages/ui/src/Components/Dashboard/Stories/EditStory.js
+++ b/packages/ui/src/Components/Dashboard/Stories/EditStory.js
@@ -3,13 +3,13 @@ import StoryForm from './StoryForm'
 import { Header } from 'semantic-ui-react'
 
 export default class EditStory extends Component {
-	render() {
-		return (
-			<div className="storyform">
-				<Header as="h1">Edit Story</Header>
-				<Header as="h5">Clear Form will result in loss of original story</Header>
-				<StoryForm editId={this.props.editId} />
-			</div>
-		)
-	}
+  render() {
+    return (
+      <div className="storyform">
+        <Header as="h1">Edit Story</Header>
+        <Header as="h5">Clear Form will result in loss of original story</Header>
+        <StoryForm editId={this.props.editId} />
+      </div>
+    )
+  }
 }

--- a/packages/ui/src/Components/Dashboard/Stories/LoadDrafts.js
+++ b/packages/ui/src/Components/Dashboard/Stories/LoadDrafts.js
@@ -23,15 +23,15 @@ export default class LoadDrafts extends Component {
 
   handleDelete = () => {
     this.setState({deleteId : this.state.deleteId})
-    console.log("Deleting draft with id: " + this.props.sDraft._id)
+    console.log('Deleting draft with id: ' + this.props.sDraft._id)
     Axios.post('/api/deleteDraft', {deleteId: this.props.sDraft._id})
       .then(res => {
-         console.log(res.data);
+        console.log(res.data)
       })
       .catch((err) => {
-         console.log(err);
+        console.log(err)
       })
-      window.location.reload()
+    window.location.reload()
   }
   moveToPublish = () => {
     let data = {
@@ -43,17 +43,17 @@ export default class LoadDrafts extends Component {
       publish_status: true
     }
     Axios.post('/api/addPublish', data)
-    .then(response => {
-      console.log(response, "Story has been published")
-    })
-    .catch(err => {
-      console.log(err, "Try again.")
-    })
+      .then(response => {
+        console.log(response, 'Story has been published')
+      })
+      .catch(err => {
+        console.log(err, 'Try again.')
+      })
     
   }
 
   handlePublish = () => {
-    console.log("Publishing draft with id: " + this.props.sDraft._id)
+    console.log('Publishing draft with id: ' + this.props.sDraft._id)
     Axios.all([this.moveToPublish(), this.handleDelete()])
   }
 
@@ -62,48 +62,48 @@ export default class LoadDrafts extends Component {
     this.props.updateParentID(this.props.sDraft._id)
   }
 
-   render () {
-     const { activeIndex } = this.state
+  render () {
+    const { activeIndex } = this.state
 
 
-     return (
-       <div className="viewStories">
-         <div>
-         <Card.Group>
-              {
-                   <Card fluid>
-                     <Card.Content>
-                       <Card.Header>{this.props.sDraft.title}</Card.Header>
-                       <Card.Meta>{this.props.sDraft.edited_timestamp}</Card.Meta>
-                       <Card.Description>{this.props.sDraft.hook}</Card.Description>
-                       <Accordion >
-                       <Accordion.Title active={activeIndex === 0} index={0} onClick={this.handleClick}>
+    return (
+      <div className="viewStories">
+        <div>
+          <Card.Group>
+            {
+              <Card fluid>
+                <Card.Content>
+                  <Card.Header>{this.props.sDraft.title}</Card.Header>
+                  <Card.Meta>{this.props.sDraft.edited_timestamp}</Card.Meta>
+                  <Card.Description>{this.props.sDraft.hook}</Card.Description>
+                  <Accordion >
+                    <Accordion.Title active={activeIndex === 0} index={0} onClick={this.handleClick}>
            							 <Icon name="dropdown" />
            						     </Accordion.Title>
-                             <Accordion.Content active={activeIndex === 0 }>
-                               <p>{this.props.sDraft.content}</p>
-                               <Button.Group widths={3}>
-                                 <Button color='blue'
-                                         name='editDraft'
-                                         as={Link}
-                                         to='/EditStory'
-                                         onClick={this.handleEdit}>Edit</Button>
-                                 <Button color='green'
-                                         name='publishDraft'
-                                         onClick={this.handlePublish}>Publish</Button>
-                                 <Button color='red'
-                                         name='deleteDraft'
-                                         onClick={this.handleDelete}>Delete</Button>
-                               </Button.Group>
-                             </Accordion.Content>
-                        </Accordion>
-                     </Card.Content>
-                  </Card>
-             }
-         </Card.Group>
-         </div>
-       </div>
+                    <Accordion.Content active={activeIndex === 0 }>
+                      <p>{this.props.sDraft.content}</p>
+                      <Button.Group widths={3}>
+                        <Button color='blue'
+                          name='editDraft'
+                          as={Link}
+                          to='/EditStory'
+                          onClick={this.handleEdit}>Edit</Button>
+                        <Button color='green'
+                          name='publishDraft'
+                          onClick={this.handlePublish}>Publish</Button>
+                        <Button color='red'
+                          name='deleteDraft'
+                          onClick={this.handleDelete}>Delete</Button>
+                      </Button.Group>
+                    </Accordion.Content>
+                  </Accordion>
+                </Card.Content>
+              </Card>
+            }
+          </Card.Group>
+        </div>
+      </div>
 
-     )
-   }
- }
+    )
+  }
+}

--- a/packages/ui/src/Components/Dashboard/Stories/LoadPublished.js
+++ b/packages/ui/src/Components/Dashboard/Stories/LoadPublished.js
@@ -20,15 +20,15 @@ export default class LoadPublished extends Component {
  	}
 
   handleDelete = () => {
-    console.log("Deleting published Story with id: " + this.props.sPublish._id)
+    console.log('Deleting published Story with id: ' + this.props.sPublish._id)
     Axios.post('/api/deletePublish', {deleteId: this.props.sPublish._id})
       .then(res => {
-         console.log(res.data);
+        console.log(res.data)
       })
       .catch((err) => {
-         console.log(err);
+        console.log(err)
       })
-      window.location.reload()
+    window.location.reload()
   }
 
   handleEdit = (e) => {
@@ -36,47 +36,47 @@ export default class LoadPublished extends Component {
     this.props.updateParentID(this.props.sPublish._id)
   }
 
-   render () {
-     const { activeIndex } = this.state
-     return (
-       <div className="viewStories">
-         <div>
-         <Card.Group>
-              {
-                   <Card fluid>
-                     <Card.Content>
-                       <Card.Header>{this.props.sPublish.title}</Card.Header>
-                       <Card.Meta>{this.props.sPublish.edited_timestamp}</Card.Meta>
-                       <Card.Description>{this.props.sPublish.hook}</Card.Description>
-                       <Accordion>
-                       <Accordion.Title active={activeIndex === 0}
-                                        index={0}
-                                        onClick={this.handleClick}
-                        >
+  render () {
+    const { activeIndex } = this.state
+    return (
+      <div className="viewStories">
+        <div>
+          <Card.Group>
+            {
+              <Card fluid>
+                <Card.Content>
+                  <Card.Header>{this.props.sPublish.title}</Card.Header>
+                  <Card.Meta>{this.props.sPublish.edited_timestamp}</Card.Meta>
+                  <Card.Description>{this.props.sPublish.hook}</Card.Description>
+                  <Accordion>
+                    <Accordion.Title active={activeIndex === 0}
+                      index={0}
+                      onClick={this.handleClick}
+                    >
            							 <Icon name="dropdown" />
            						     </Accordion.Title>
-                             <Accordion.Content active={activeIndex === 0}>
-                               <p>{this.props.sPublish.content}</p>
-                               <Button.Group widths={2}>
-                                 <Button color='blue'
-                                         name='editDraft'
-                                         as={Link}
-                                         to='/EditStory'
-                                         onClick={this.handleEdit}>Edit</Button>
-                                 <Button color='red'
-                                         name='deleteDraft'
-                                         onClick={this.handleDelete}>Delete</Button>
-                               </Button.Group>
-                             </Accordion.Content>
-                        </Accordion>
-                     </Card.Content>
-                     </Card>
+                    <Accordion.Content active={activeIndex === 0}>
+                      <p>{this.props.sPublish.content}</p>
+                      <Button.Group widths={2}>
+                        <Button color='blue'
+                          name='editDraft'
+                          as={Link}
+                          to='/EditStory'
+                          onClick={this.handleEdit}>Edit</Button>
+                        <Button color='red'
+                          name='deleteDraft'
+                          onClick={this.handleDelete}>Delete</Button>
+                      </Button.Group>
+                    </Accordion.Content>
+                  </Accordion>
+                </Card.Content>
+              </Card>
 
-                 }
-         </Card.Group>
-         </div>
-       </div>
+            }
+          </Card.Group>
+        </div>
+      </div>
 
-     )
-   }
- }
+    )
+  }
+}

--- a/packages/ui/src/Components/Dashboard/Stories/NewStory.js
+++ b/packages/ui/src/Components/Dashboard/Stories/NewStory.js
@@ -2,12 +2,12 @@ import React, { Component } from 'react'
 import StoryForm from './StoryForm'
 import { Header } from 'semantic-ui-react'
 export default class NewStory extends Component {
-	render() {
-		return (
-			<div className="storyform">
-				<Header as="h1">Create New Story</Header>
-				<StoryForm />
-			</div>
-		)
-	}
+  render() {
+    return (
+      <div className="storyform">
+        <Header as="h1">Create New Story</Header>
+        <StoryForm />
+      </div>
+    )
+  }
 }

--- a/packages/ui/src/Components/Dashboard/Stories/StoryForm.js
+++ b/packages/ui/src/Components/Dashboard/Stories/StoryForm.js
@@ -26,21 +26,21 @@ export default class StoryForm extends Component {
 
   componentDidMount = () => {
     if(this.props.editId !== undefined) {
-    Axios.post('/api/getStoryEdit', { id: this.props.editId })
+      Axios.post('/api/getStoryEdit', { id: this.props.editId })
         .then((response) => {
-         console.log(response)
-         this.setState({
-           _id : response.data._id,
-         title :response.data.title,
-         hook :  response.data.hook,
-         content : response.data.content,
-         editedTimestamp : response.data.edited_timestamp,
-         publish_status : response.data.publish_status
-      })
-    })
-       .catch((error) => {
-         console.log(error)
-      })
+          console.log(response)
+          this.setState({
+            _id : response.data._id,
+            title :response.data.title,
+            hook :  response.data.hook,
+            content : response.data.content,
+            editedTimestamp : response.data.edited_timestamp,
+            publish_status : response.data.publish_status
+          })
+        })
+        .catch((error) => {
+          console.log(error)
+        })
     }
   }
 
@@ -49,61 +49,61 @@ export default class StoryForm extends Component {
     await this.setState({ publish_status : true })
     /*console.log(this.state._id) TESTING */
     if(this.state._id !== undefined && this.state._id !== '') {
-    Axios.post("/api/editedStory", this.state)
-      .then(response => {
-        console.log(response, "Story has been edited and saved to published")
-      })
-      .catch(err => {
-        console.log(err, "Try again.")
-      })
+      Axios.post('/api/editedStory', this.state)
+        .then(response => {
+          console.log(response, 'Story has been edited and saved to published')
+        })
+        .catch(err => {
+          console.log(err, 'Try again.')
+        })
     } else {
-      Axios.post("/api/addPublish", this.state)
-      .then(response => {
-        console.log(response, "Story has been published")
-      })
-      .catch(err => {
-        console.log(err, "Try again.")
-      })
+      Axios.post('/api/addPublish', this.state)
+        .then(response => {
+          console.log(response, 'Story has been published')
+        })
+        .catch(err => {
+          console.log(err, 'Try again.')
+        })
     }
     this.open()
     /*console.log(this.state) TESTING */
   }
 
- /*Checks for publish_status if load through edit*/
+  /*Checks for publish_status if load through edit*/
   handleSave = (e) => {
     if(this.state.publish_status) {
       this.handlePublish()
     } else if(this.state._id !== undefined && this.state._id !== '') {
-      Axios.post("/api/editedStory", this.state)
-       .then(response => {
-         console.log(response, "Story has been edited and saved to drafts")
-       })
-       .catch(err => {
-         console.log(err, "Try again.")
-       })
-     } else {
-      Axios.post("/api/addDraft", this.state)
-      .then(response => {
-        console.log(response, "Story saved to drafts")
-      })
-      .catch(err => {
-        console.log(err, "Try again.")
-      })
-     }
+      Axios.post('/api/editedStory', this.state)
+        .then(response => {
+          console.log(response, 'Story has been edited and saved to drafts')
+        })
+        .catch(err => {
+          console.log(err, 'Try again.')
+        })
+    } else {
+      Axios.post('/api/addDraft', this.state)
+        .then(response => {
+          console.log(response, 'Story saved to drafts')
+        })
+        .catch(err => {
+          console.log(err, 'Try again.')
+        })
+    }
     this.open()
     /*console.log(this.state) TESTING */
   }
 
   clearForm = () => {
     this.setState({
-    title: '',
-    hook: '',
-    content: '',
-    publish_status: false,
-    open: false,
-    isEnabled : false })
+      title: '',
+      hook: '',
+      content: '',
+      publish_status: false,
+      open: false,
+      isEnabled : false })
     this.close()
- }
+  }
 
   open = () => this.setState({ open: true })
   close = () => this.setState({ open: false })
@@ -121,57 +121,57 @@ export default class StoryForm extends Component {
       <Segment>
         <Form>
           <Form.Field>
-          <label>Title</label>
-          <input name="title"
-                 placeholder="Title"
-                 value={this.state.title}
-                 onChange={this.onChange}
-          />
+            <label>Title</label>
+            <input name="title"
+              placeholder="Title"
+              value={this.state.title}
+              onChange={this.onChange}
+            />
           </Form.Field>
           <Form.Field>
-          <label>Subtitle</label>
-          <input name="hook"
-                 placeholder="Subtitle"
-                 value={this.state.hook}
-                 onChange={this.onChange}
-         />
-         </Form.Field>
-         <Form.Field>
-         <label>Content</label>
-         <TextArea name="content"
-                   placeholder='Your Story'
-                   rows="15"
-                   value={this.state.content}
-                   onChange={this.onChange}
-         />
-         </Form.Field>
-         <Grid stackable columns={3}>
-          <Grid.Column>
-             <Button color="blue"
-                     fluid
-                     disabled={!this.state.isEnabled}
-                     onClick={this.handleSave}>Save</Button>
-             <Confirm open={this.state.open}
-                      content='Your Story was saved as a draft'
-                      onCancel={this.close}
-                      onConfirm={this.clearForm}
-             />
-          </Grid.Column>
-          <Grid.Column >
-             <Button color="green"
-                     fluid
-                     disabled={!this.state.isEnabled}
-                     onClick={this.handlePublish}>Publish</Button>
-             <Confirm open={this.state.open}
-                      content='Your Story was published'
-                      onCancel={this.close}
-                      onConfirm={this.clearForm}
-             />
-          </Grid.Column>
-          <Grid.Column>
-            <Button color="red" fluid /*floated='right'*/ onClick={this.open}>Clear Form</Button>
-            <Confirm open={this.state.open} onCancel={this.close} onConfirm={this.clearForm} />
-          </Grid.Column>
+            <label>Subtitle</label>
+            <input name="hook"
+              placeholder="Subtitle"
+              value={this.state.hook}
+              onChange={this.onChange}
+            />
+          </Form.Field>
+          <Form.Field>
+            <label>Content</label>
+            <TextArea name="content"
+              placeholder='Your Story'
+              rows="15"
+              value={this.state.content}
+              onChange={this.onChange}
+            />
+          </Form.Field>
+          <Grid stackable columns={3}>
+            <Grid.Column>
+              <Button color="blue"
+                fluid
+                disabled={!this.state.isEnabled}
+                onClick={this.handleSave}>Save</Button>
+              <Confirm open={this.state.open}
+                content='Your Story was saved as a draft'
+                onCancel={this.close}
+                onConfirm={this.clearForm}
+              />
+            </Grid.Column>
+            <Grid.Column >
+              <Button color="green"
+                fluid
+                disabled={!this.state.isEnabled}
+                onClick={this.handlePublish}>Publish</Button>
+              <Confirm open={this.state.open}
+                content='Your Story was published'
+                onCancel={this.close}
+                onConfirm={this.clearForm}
+              />
+            </Grid.Column>
+            <Grid.Column>
+              <Button color="red" fluid /*floated='right'*/ onClick={this.open}>Clear Form</Button>
+              <Confirm open={this.state.open} onCancel={this.close} onConfirm={this.clearForm} />
+            </Grid.Column>
           </Grid>
         </Form>
       </Segment>

--- a/packages/ui/src/Components/Dashboard/Stories/ViewStories.js
+++ b/packages/ui/src/Components/Dashboard/Stories/ViewStories.js
@@ -25,35 +25,35 @@ export default class ViewStories extends Component {
 
   componentDidMount = async () => {
     Axios.get('/api/StoriesCount')
-     .then(async(res) => {
+      .then(async(res) => {
         let tempCount = JSON.parse(res.data.count_info)
         await this.setState({draftCount: tempCount[0].draftCount})
         await this.setState({publishCount: tempCount[0].publishCount})
         await this.setState({maxPublish: Math.ceil(this.state.publishCount/5)})
         await this.setState({maxDraft: Math.ceil(this.state.draftCount/5)})
         console.log(res)
-     })
+      })
      
-     if(!(((this.state.draftCount) / this.state.draftPage * 5) < 1)) {
-       this.getDraft()
-     }
+    if(!(((this.state.draftCount) / this.state.draftPage * 5) < 1)) {
+      this.getDraft()
+    }
      
-     if(!(((this.state.publishCount) / this.state.publishPage * 5) < 1)) {
-        this.getPublished() 
-     }
+    if(!(((this.state.publishCount) / this.state.publishPage * 5) < 1)) {
+      this.getPublished() 
+    }
   }
           
   getDraft = () => {
     Axios.get('/api/draftStories', {
       params: { page: this.state.draftPage }
-     })
+    })
       .then(res => {
         if(res.data.status !== 'FAILURE') {
           let tempDraftStory = JSON.parse(res.data.draft_info)
           console.log(tempDraftStory)
           this.setState({
-          draftStory : tempDraftStory
-        })
+            draftStory : tempDraftStory
+          })
         } 
       })
   }
@@ -67,8 +67,8 @@ export default class ViewStories extends Component {
           let tempPubStory = JSON.parse(res.data.published_info)
           console.log(tempPubStory)
           this.setState({
-          publishStory : tempPubStory
-        })
+            publishStory : tempPubStory
+          })
         } 
       })
   }
@@ -79,9 +79,9 @@ export default class ViewStories extends Component {
   updateParent = (e) => this.props.updateGrandparent()
 
   updateParentID = (value) => {
-     this.props.updateGrandparentID(value)
-     console.log(value)
-   }
+    this.props.updateGrandparentID(value)
+    console.log(value)
+  }
 
    handleMoreStories = async () => {
      if(this.state.activeItem === 'loadPublished'){
@@ -89,9 +89,9 @@ export default class ViewStories extends Component {
        await this.setState({publishedPage: this.state.publishedPage + 1 })
        this.componentDidMount()
      } else {
-         this.setState({publishedPage: 1})
-         await this.setState({draftPage: this.state.draftPage + 1})
-         this.componentDidMount()
+       this.setState({publishedPage: 1})
+       await this.setState({draftPage: this.state.draftPage + 1})
+       this.componentDidMount()
      }
      
    }
@@ -104,76 +104,76 @@ export default class ViewStories extends Component {
          this.componentDidMount()
        }
      } else {
-         this.setState({publishedPage: 1})
-         if(this.state.draftPage > 1) {
-           await this.setState({draftPage: this.state.draftPage - 1})
-           this.componentDidMount()
-         }
+       this.setState({publishedPage: 1})
+       if(this.state.draftPage > 1) {
+         await this.setState({draftPage: this.state.draftPage - 1})
+         this.componentDidMount()
+       }
      }
    }
 
 
-  render () {
+   render () {
 
-    let activeItem  = this.state.activeItem
+     let activeItem  = this.state.activeItem
     
-    let chooseRender;
-    if(activeItem === 'loadPublished'){
-      chooseRender = (
-        this.state.publishStory && this.state.publishStory.map(sPublish =>
-          <LoadPublished key={sPublish.edited_timestamp}
-                         sPublish={sPublish}
-                         updateParent={this.updateParent}
-                         edit={this.props.activeItem}
-                         editId={this.props.editId}
-                         updateParentID={this.updateParentID}/> )
-      )
-    } else if(activeItem === 'loadDrafts'){
-      chooseRender = (
-        this.state.draftStory && this.state.draftStory.map(sDraft =>
-          <LoadDrafts key={sDraft.edited_timestamp}
-                      sDraft={sDraft}
-                      updateParent={this.updateParent}
-                      edit={this.props.activeItem}
-                      editId={this.props.editId}
-                      updateParentID={this.updateParentID}/> )
-      )
-    }
+     let chooseRender
+     if(activeItem === 'loadPublished'){
+       chooseRender = (
+         this.state.publishStory && this.state.publishStory.map(sPublish =>
+           <LoadPublished key={sPublish.edited_timestamp}
+             sPublish={sPublish}
+             updateParent={this.updateParent}
+             edit={this.props.activeItem}
+             editId={this.props.editId}
+             updateParentID={this.updateParentID}/> )
+       )
+     } else if(activeItem === 'loadDrafts'){
+       chooseRender = (
+         this.state.draftStory && this.state.draftStory.map(sDraft =>
+           <LoadDrafts key={sDraft.edited_timestamp}
+             sDraft={sDraft}
+             updateParent={this.updateParent}
+             edit={this.props.activeItem}
+             editId={this.props.editId}
+             updateParentID={this.updateParentID}/> )
+       )
+     }
 
-    return (
+     return (
        <div>
-        <Segment>
-        <div className="storyButtons">
-          <Button.Group widths={2}>
-            <Button name='loadPublished'
-                    active={activeItem === 'loadPublished'}
-                    onClick={this.handlePublishClick}>Published</Button>
-            <Button name='loadDrafts'
-                    active={activeItem === 'loadDrafts'}
-                    onClick={this.handleDraftClick}>Drafts</Button>
-          </Button.Group>     
-        </div>
+         <Segment>
+           <div className="storyButtons">
+             <Button.Group widths={2}>
+               <Button name='loadPublished'
+                 active={activeItem === 'loadPublished'}
+                 onClick={this.handlePublishClick}>Published</Button>
+               <Button name='loadDrafts'
+                 active={activeItem === 'loadDrafts'}
+                 onClick={this.handleDraftClick}>Drafts</Button>
+             </Button.Group>     
+           </div>
            { chooseRender }
-        </Segment>
-        <div>
-        <Button.Group widths={2}>
-          <Button labelPosition='left' 
-                  icon='left chevron' 
-                  content='Back' 
-                  onClick={this.handleLessStories}
-                  />
-          <Button labelPosition='right' 
-                  icon='right chevron' 
-                  content='Forward' 
-                  disabled={(this.state.activeItem === 'loadPublished' &&
+         </Segment>
+         <div>
+           <Button.Group widths={2}>
+             <Button labelPosition='left' 
+               icon='left chevron' 
+               content='Back' 
+               onClick={this.handleLessStories}
+             />
+             <Button labelPosition='right' 
+               icon='right chevron' 
+               content='Forward' 
+               disabled={(this.state.activeItem === 'loadPublished' &&
                     this.state.maxPublish === this.state.publishedPage) || 
                     (this.state.activeItem === 'loadDrafts' &&
                     this.state.maxDraft === this.state.draftPage)}
-                  onClick={this.handleMoreStories}
-                  />
-       </Button.Group>
+               onClick={this.handleMoreStories}
+             />
+           </Button.Group>
+         </div>
        </div>
-     </div>
-    )
-  }
+     )
+   }
 }

--- a/packages/ui/src/Components/Dashboard/UpcomingEvents.js
+++ b/packages/ui/src/Components/Dashboard/UpcomingEvents.js
@@ -3,205 +3,205 @@ import { Button, Header, Icon, Menu, Table } from 'semantic-ui-react'
 import Moment from 'moment'
 import Axios from 'axios'
 import { Modal } from 'semantic-ui-react'
-import { Link } from "react-router-dom";
+import { Link } from 'react-router-dom'
 
 class UpcomingEvents extends Component {
-	constructor(props) {
-		super(props)
-		this.state = {
-			currentDate: new Moment().format('MM-DD-YY'),
-			events: [],
-			dates: [ new Moment().format('MM-DD-YY') ],
-			lastDate: '',
-			numOfDays: 5,
-			dateToDelete: '',
-			open: false
-		}
-	}
+  constructor(props) {
+    super(props)
+    this.state = {
+      currentDate: new Moment().format('MM-DD-YY'),
+      events: [],
+      dates: [ new Moment().format('MM-DD-YY') ],
+      lastDate: '',
+      numOfDays: 5,
+      dateToDelete: '',
+      open: false
+    }
+  }
 
-	componentDidMount() {
-		this.initializeDates()
-		this.updateEvents(this.state.dates)
-	}
+  componentDidMount() {
+    this.initializeDates()
+    this.updateEvents(this.state.dates)
+  }
 
 	initializeDates = () => {
-		for (let index = 1; index <= this.state.numOfDays; index++) {
-			this.state.dates.push(Moment(this.state.currentDate, 'MM-DD-YY').add(index, 'd').format('MM-DD-YY'))
-		}
-		this.setState({ lastDate: this.state.dates.slice(-1)[0] })
+	  for (let index = 1; index <= this.state.numOfDays; index++) {
+	    this.state.dates.push(Moment(this.state.currentDate, 'MM-DD-YY').add(index, 'd').format('MM-DD-YY'))
+	  }
+	  this.setState({ lastDate: this.state.dates.slice(-1)[0] })
 	}
 
 	updateEvents = (dates) => {
-		let paths = []
-		dates.forEach((date) => {
-			const path = '/api/fullEvent?date=' + date
-			paths.push(path)
-		})
+	  let paths = []
+	  dates.forEach((date) => {
+	    const path = '/api/fullEvent?date=' + date
+	    paths.push(path)
+	  })
 
-		Axios.all(paths.map((l) => Axios.get(l)))
-			.then(
-				Axios.spread((...res) => {
-					res.forEach((event) => {
-						if (event.data['event_info']) {
-							let temp = JSON.parse(event.data['event_info'])
-							let newEvent = {
-								coordinator: event.data.coordinator,
-								phone: event.data.coordinator_phone,
-								location: event.data.location,
-								volunteer_signups: temp.length,
-								servings: this.calculateServings(temp),
-								volunteers: temp,
-								date: event.data.date
-							}
-							this.setState((prevState) => ({
-								events: [ ...prevState.events, newEvent ]
-							}))
-						}
-					})
-				})
-			)
-			.catch((err) => {
-				console.log(err)
-			})
+	  Axios.all(paths.map((l) => Axios.get(l)))
+	    .then(
+	      Axios.spread((...res) => {
+	        res.forEach((event) => {
+	          if (event.data['event_info']) {
+	            let temp = JSON.parse(event.data['event_info'])
+	            let newEvent = {
+	              coordinator: event.data.coordinator,
+	              phone: event.data.coordinator_phone,
+	              location: event.data.location,
+	              volunteer_signups: temp.length,
+	              servings: this.calculateServings(temp),
+	              volunteers: temp,
+	              date: event.data.date
+	            }
+	            this.setState((prevState) => ({
+	              events: [ ...prevState.events, newEvent ]
+	            }))
+	          }
+	        })
+	      })
+	    )
+	    .catch((err) => {
+	      console.log(err)
+	    })
 	}
 
 	calculateServings = (volunteers) => {
-		let totalServings = 0
-		if (volunteers) {
-			volunteers.map((volunteer) => (totalServings += volunteer.servings))
-		}
-		return totalServings
+	  let totalServings = 0
+	  if (volunteers) {
+	    volunteers.map((volunteer) => (totalServings += volunteer.servings))
+	  }
+	  return totalServings
 	}
 
 	displayDeleteModal = (event, data) => {
-		this.setState({ dateToDelete: data.name })
-		this.openModal()
+	  this.setState({ dateToDelete: data.name })
+	  this.openModal()
 	}
 
 	deleteEvent = (event, data) => {
-		let newEvents = this.state.events.filter((obj) => {
-			return obj.date !== data.name
-		})
-		this.setState({
-			events: newEvents
-		})
+	  let newEvents = this.state.events.filter((obj) => {
+	    return obj.date !== data.name
+	  })
+	  this.setState({
+	    events: newEvents
+	  })
 
-		const deletedEvent = {
-			date: data.name
-		}
+	  const deletedEvent = {
+	    date: data.name
+	  }
 
-		Axios.post('/api/deleteEvent', deletedEvent)
-			.then((response) => {
-				console.log(response, 'Deleted Event ' + data.name)
-			})
-			.catch((err) => {
-				console.log(err, 'Try again.')
-			})
+	  Axios.post('/api/deleteEvent', deletedEvent)
+	    .then((response) => {
+	      console.log(response, 'Deleted Event ' + data.name)
+	    })
+	    .catch((err) => {
+	      console.log(err, 'Try again.')
+	    })
 
-		this.closeModal()
+	  this.closeModal()
 	}
 
 	loadPrev = () => {
-		this.setState({ events: [] }, () => {
-			let newDates = []
-			for (let i = this.state.numOfDays; i > 0; i--) {
-				newDates.push(Moment(this.state.currentDate, 'MM-DD-YY').subtract(i, 'd').format('MM-DD-YY'))
-			}
-			this.setState({
-				lastDate: newDates.slice(-1)[0],
-				currentDate: newDates[0]
-			})
-			this.updateEvents(newDates)
-		})
+	  this.setState({ events: [] }, () => {
+	    let newDates = []
+	    for (let i = this.state.numOfDays; i > 0; i--) {
+	      newDates.push(Moment(this.state.currentDate, 'MM-DD-YY').subtract(i, 'd').format('MM-DD-YY'))
+	    }
+	    this.setState({
+	      lastDate: newDates.slice(-1)[0],
+	      currentDate: newDates[0]
+	    })
+	    this.updateEvents(newDates)
+	  })
 	}
 
 	loadNext = () => {
-		this.setState({ events: [] }, () => {
-			let newDates = []
-			for (let i = 1; i <= this.state.numOfDays; i++) {
-				newDates.push(Moment(this.state.lastDate, 'MM-DD-YY').add(i, 'd').format('MM-DD-YY'))
-			}
-			this.setState({
-				lastDate: newDates.slice(-1)[0],
-				currentDate: newDates[0]
-			})
-			this.updateEvents(newDates)
-		})
+	  this.setState({ events: [] }, () => {
+	    let newDates = []
+	    for (let i = 1; i <= this.state.numOfDays; i++) {
+	      newDates.push(Moment(this.state.lastDate, 'MM-DD-YY').add(i, 'd').format('MM-DD-YY'))
+	    }
+	    this.setState({
+	      lastDate: newDates.slice(-1)[0],
+	      currentDate: newDates[0]
+	    })
+	    this.updateEvents(newDates)
+	  })
 	}
 
 	closeModal = () => {
-		this.setState({ open: false })
+	  this.setState({ open: false })
 	}
 
 	openModal = () => {
-		this.setState({ open: true })
+	  this.setState({ open: true })
 	}
 
 	render() {
-		return (
-			<div>
-				<Header as="h2">Upcoming Events</Header>
-				<Table celled textAlign="center" selectable>
-					<Table.Header>
-						<Table.Row>
-							<Table.HeaderCell>Date</Table.HeaderCell>
-							<Table.HeaderCell>Location</Table.HeaderCell>
-							<Table.HeaderCell>Volunteer Signups</Table.HeaderCell>
-							<Table.HeaderCell>Servings</Table.HeaderCell>
-							<Table.HeaderCell />
-						</Table.Row>
-					</Table.Header>
-					<Table.Body>
-						{this.state.events &&
+	  return (
+	    <div>
+	      <Header as="h2">Upcoming Events</Header>
+	      <Table celled textAlign="center" selectable>
+	        <Table.Header>
+	          <Table.Row>
+	            <Table.HeaderCell>Date</Table.HeaderCell>
+	            <Table.HeaderCell>Location</Table.HeaderCell>
+	            <Table.HeaderCell>Volunteer Signups</Table.HeaderCell>
+	            <Table.HeaderCell>Servings</Table.HeaderCell>
+	            <Table.HeaderCell />
+	          </Table.Row>
+	        </Table.Header>
+	        <Table.Body>
+	          {this.state.events &&
 							this.state.events.map((event, index) => (
-								<Table.Row key={index}>
-									<Table.Cell width={2}>
-										<Button color="teal" as={Link} to="/EditEvent" onClick={() => this.props.updateActiveDate(event.date)}>
-											{event.date}
-										</Button>
-									</Table.Cell>
-									<Table.Cell>{event.location}</Table.Cell>
-									<Table.Cell>{event['volunteer_signups']}</Table.Cell>
-									<Table.Cell>{event.servings}</Table.Cell>
-									<Table.Cell collapsing>
-										<Button negative onClick={this.displayDeleteModal} name={event.date}>
+							  <Table.Row key={index}>
+							    <Table.Cell width={2}>
+							      <Button color="teal" as={Link} to="/EditEvent" onClick={() => this.props.updateActiveDate(event.date)}>
+							        {event.date}
+							      </Button>
+							    </Table.Cell>
+							    <Table.Cell>{event.location}</Table.Cell>
+							    <Table.Cell>{event['volunteer_signups']}</Table.Cell>
+							    <Table.Cell>{event.servings}</Table.Cell>
+							    <Table.Cell collapsing>
+							      <Button negative onClick={this.displayDeleteModal} name={event.date}>
 											Delete
-										</Button>
-									</Table.Cell>
-								</Table.Row>
+							      </Button>
+							    </Table.Cell>
+							  </Table.Row>
 							))}
-						<Modal open={this.state.open} onClose={this.closeModal} closeIcon>
-							<Header icon="calendar alternate outline" content="Delete Event" />
-							<Modal.Content>
-								<h3>Are you sure you want delete event {this.state.dateToDelete}?</h3>
-							</Modal.Content>
-							<Modal.Actions>
-								<Button color="red" onClick={this.closeModal}>
-									<Icon name="remove" /> No
-								</Button>
-								<Button color="green" onClick={this.deleteEvent} name={this.state.dateToDelete}>
-									<Icon name="checkmark" /> Yes
-								</Button>
-							</Modal.Actions>
-						</Modal>
-					</Table.Body>
-					<Table.Footer fullWidth>
-						<Table.Row>
-							<Table.HeaderCell colSpan="5">
-								<Menu floated="right">
-									<Menu.Item as="a" icon onClick={this.loadPrev}>
-										<Icon name="chevron left" />
-									</Menu.Item>
-									<Menu.Item as="a" icon onClick={this.loadNext}>
-										<Icon name="chevron right" />
-									</Menu.Item>
-								</Menu>
-							</Table.HeaderCell>
-						</Table.Row>
-					</Table.Footer>
-				</Table>
-			</div>
-		)
+	          <Modal open={this.state.open} onClose={this.closeModal} closeIcon>
+	            <Header icon="calendar alternate outline" content="Delete Event" />
+	            <Modal.Content>
+	              <h3>Are you sure you want delete event {this.state.dateToDelete}?</h3>
+	            </Modal.Content>
+	            <Modal.Actions>
+	              <Button color="red" onClick={this.closeModal}>
+	                <Icon name="remove" /> No
+	              </Button>
+	              <Button color="green" onClick={this.deleteEvent} name={this.state.dateToDelete}>
+	                <Icon name="checkmark" /> Yes
+	              </Button>
+	            </Modal.Actions>
+	          </Modal>
+	        </Table.Body>
+	        <Table.Footer fullWidth>
+	          <Table.Row>
+	            <Table.HeaderCell colSpan="5">
+	              <Menu floated="right">
+	                <Menu.Item as="a" icon onClick={this.loadPrev}>
+	                  <Icon name="chevron left" />
+	                </Menu.Item>
+	                <Menu.Item as="a" icon onClick={this.loadNext}>
+	                  <Icon name="chevron right" />
+	                </Menu.Item>
+	              </Menu>
+	            </Table.HeaderCell>
+	          </Table.Row>
+	        </Table.Footer>
+	      </Table>
+	    </div>
+	  )
 	}
 }
 

--- a/packages/ui/src/Components/Dashboard/VolunteerList.js
+++ b/packages/ui/src/Components/Dashboard/VolunteerList.js
@@ -64,7 +64,7 @@ class VolunteerList extends Component {
           </Table.Header>
           <Table.Body>
             {// If not volunteers is not empty, go ahead and map it to table
-            filteredVolunteers &&
+              filteredVolunteers &&
               filteredVolunteers.map(item => (
                 <Table.Row key={item.email}>
                   <Table.Cell>

--- a/packages/ui/src/Components/Dashboard/WelcomeMessage.js
+++ b/packages/ui/src/Components/Dashboard/WelcomeMessage.js
@@ -5,8 +5,8 @@ export default class WelcomeMessage extends Component {
   render() {
     return (
       <div className="dashWelcome">
-       <Header as="h1">Welcome Back</Header>
-       </div>
-     )
+        <Header as="h1">Welcome Back</Header>
+      </div>
+    )
   }
 }

--- a/packages/ui/src/Components/Home/DonateButton.js
+++ b/packages/ui/src/Components/Home/DonateButton.js
@@ -2,13 +2,13 @@ import React from 'react'
 import { Button } from 'semantic-ui-react'
 
 const DonateButton = () => {
-    return (
-        <div className='donateButton'>
-            <Button size='massive' color='teal'>
+  return (
+    <div className='donateButton'>
+      <Button size='massive' color='teal'>
                 DONATE
-            </Button>
-        </div>
-    );
+      </Button>
+    </div>
+  )
 }
 
 export default DonateButton

--- a/packages/ui/src/Components/Home/Slide.js
+++ b/packages/ui/src/Components/Home/Slide.js
@@ -2,18 +2,18 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 const Slide = ({ image }) => {
-    const styles = {
-      backgroundImage: `url(${image})`,
-      backgroundPosition: 'center top',
-      backgroundSize: 'auto 100%',
-      objectFit: 'cover',
-      backgroundRepeat: 'no-repeat',
-      float: 'left',
-    }
-    return <div className="slide" style={styles}></div>
+  const styles = {
+    backgroundImage: `url(${image})`,
+    backgroundPosition: 'center top',
+    backgroundSize: 'auto 100%',
+    objectFit: 'cover',
+    backgroundRepeat: 'no-repeat',
+    float: 'left',
   }
-
-  Slide.propTypes = {
-    image: PropTypes.string
+  return <div className="slide" style={styles}></div>
 }
-  export default Slide
+
+Slide.propTypes = {
+  image: PropTypes.string
+}
+export default Slide

--- a/packages/ui/src/Components/Home/Slider.js
+++ b/packages/ui/src/Components/Home/Slider.js
@@ -4,99 +4,99 @@ import Axios from 'axios'
 import '../Stylesheets/Slider.css'
 
 const defaultImages = [
-    "https://s3.us-east-2.amazonaws.com/dzuz14/thumbnails/aurora.jpg",
-    "https://s3.us-east-2.amazonaws.com/dzuz14/thumbnails/canyon.jpg",
-    "https://s3.us-east-2.amazonaws.com/dzuz14/thumbnails/city.jpg",
-    "https://s3.us-east-2.amazonaws.com/dzuz14/thumbnails/desert.jpg",
-    "https://s3.us-east-2.amazonaws.com/dzuz14/thumbnails/mountains.jpg",
-    "https://s3.us-east-2.amazonaws.com/dzuz14/thumbnails/redsky.jpg",
-    "https://s3.us-east-2.amazonaws.com/dzuz14/thumbnails/sandy-shores.jpg",
-    "https://s3.us-east-2.amazonaws.com/dzuz14/thumbnails/tree-of-life.jpg"
+  'https://s3.us-east-2.amazonaws.com/dzuz14/thumbnails/aurora.jpg',
+  'https://s3.us-east-2.amazonaws.com/dzuz14/thumbnails/canyon.jpg',
+  'https://s3.us-east-2.amazonaws.com/dzuz14/thumbnails/city.jpg',
+  'https://s3.us-east-2.amazonaws.com/dzuz14/thumbnails/desert.jpg',
+  'https://s3.us-east-2.amazonaws.com/dzuz14/thumbnails/mountains.jpg',
+  'https://s3.us-east-2.amazonaws.com/dzuz14/thumbnails/redsky.jpg',
+  'https://s3.us-east-2.amazonaws.com/dzuz14/thumbnails/sandy-shores.jpg',
+  'https://s3.us-east-2.amazonaws.com/dzuz14/thumbnails/tree-of-life.jpg'
 ]
 
 export default class Slider extends Component {
-    constructor(props) {
-      super(props)
-      this.state = {
-        images: [],
-        currentImageIndex: 0,
-        // Timer for transitions
-        timer: null,
-        counter: 0,
-      }
+  constructor(props) {
+    super(props)
+    this.state = {
+      images: [],
+      currentImageIndex: 0,
+      // Timer for transitions
+      timer: null,
+      counter: 0,
     }
+  }
 
     componentDidMount = () => {
-        let timer = setInterval(this.tick, 1000)
-        let urls = []
-        Axios.get('/api/getImages/', {
-            params: {
-                isFrontPage: true,
-                needNotOnFront: false
-            }
-        })
+      let timer = setInterval(this.tick, 1000)
+      let urls = []
+      Axios.get('/api/getImages/', {
+        params: {
+          isFrontPage: true,
+          needNotOnFront: false
+        }
+      })
         .then((res) => {
-            urls = res.data
-            console.log(urls)
-            console.log(urls.length)
-            // Else, set the urls to the default image urls given (TESTING ONLY)
-            if(urls.length === 0) {
-                urls = defaultImages
-            }
-            this.setState({
-                images: urls,
-                timer: timer
-            })
+          urls = res.data
+          console.log(urls)
+          console.log(urls.length)
+          // Else, set the urls to the default image urls given (TESTING ONLY)
+          if(urls.length === 0) {
+            urls = defaultImages
+          }
+          this.setState({
+            images: urls,
+            timer: timer
+          })
         })
         .catch((err) => {
-            // handle error
-            console.log(err)
+          // handle error
+          console.log(err)
         })
     }
 
     componentWillUnmount = () => {
-        clearInterval(this.state.timer)
-        this.setState({
-            images: []
-        })
+      clearInterval(this.state.timer)
+      this.setState({
+        images: []
+      })
     }
 
     tick = () => {
-        this.setState(prevState => ({
-          counter: prevState.counter + 1
-        }));
-        if(this.state.counter % 5 === 0) {
-            this.nextSlide()
-        }
+      this.setState(prevState => ({
+        counter: prevState.counter + 1
+      }))
+      if(this.state.counter % 5 === 0) {
+        this.nextSlide()
+      }
     }
 
     nextSlide = () => {
-        // This makes the carousel infinite. Consistently
-        // changes the index of the rest of the images
-        let [first, ...rest] = this.state.images;
-        let images = [...rest, first];
-        return this.setState({
-            images: images,
-            currentImageIndex: 0,
-            counter: 0
-        })
+      // This makes the carousel infinite. Consistently
+      // changes the index of the rest of the images
+      let [first, ...rest] = this.state.images
+      let images = [...rest, first]
+      return this.setState({
+        images: images,
+        currentImageIndex: 0,
+        counter: 0
+      })
     }
 
     render() {
-        return (
-            <div className="slider">
-                <div className="slider-wrapper" onClick= {this.nextSlide}>
-                    {
-                        this.state.images.length > 0 && this.state.images.map((image, i) => (
-                            <Slide
-                                key={i}
-                                image={image}
-                            />
-                        ))
-                    }
-                </div>
-            </div>
-        );
+      return (
+        <div className="slider">
+          <div className="slider-wrapper" onClick= {this.nextSlide}>
+            {
+              this.state.images.length > 0 && this.state.images.map((image, i) => (
+                <Slide
+                  key={i}
+                  image={image}
+                />
+              ))
+            }
+          </div>
+        </div>
+      )
     }
-  }
+}
 

--- a/packages/ui/src/Components/Volunteer/EventList.js
+++ b/packages/ui/src/Components/Volunteer/EventList.js
@@ -1,6 +1,6 @@
-import React, { Component } from "react"
-import { Table, Container, Header } from "semantic-ui-react"
-import Axios from "axios"
+import React, { Component } from 'react'
+import { Table, Container, Header } from 'semantic-ui-react'
+import Axios from 'axios'
 
 class EventList extends Component {
   constructor(props) {
@@ -21,23 +21,23 @@ class EventList extends Component {
   }
 
   async componentDidMount() {
-    let path = "/api/volunteerInformation?date=" + this.props.date
+    let path = '/api/volunteerInformation?date=' + this.props.date
     Axios.get(path)
       .then(res => {
         let persons = []
-        if (res.data["event_info"]) {
-          let data = JSON.parse(res.data["event_info"])
+        if (res.data['event_info']) {
+          let data = JSON.parse(res.data['event_info'])
           data.map(person => persons.push(person))
           this.setState({ volunteers: persons })
         }
       })
       .catch(err => {
-        console.log(err, "Error Retrieving List")
+        console.log(err, 'Error Retrieving List')
       })
   }
 
   render() {
-      return(
+    return(
       <div>
         <Container>
           <h1>Volunteers</h1>
@@ -78,7 +78,7 @@ class EventList extends Component {
           </Table>
         </Container>
       </div>
-      )
+    )
   }
 }
 

--- a/packages/ui/src/Components/Volunteer/Item.js
+++ b/packages/ui/src/Components/Volunteer/Item.js
@@ -3,164 +3,164 @@ import { Header, Form, Button, Dropdown, Segment } from 'semantic-ui-react'
 import '../Stylesheets/Item.css'
 
 export default class Item extends Component {
-	constructor(props) {
-		super(props)
-		this.onChange = this.onChange.bind(this)
-		this.onCategoryChange = this.onCategoryChange.bind(this)
-		this.onSubmit = this.onSubmit.bind(this)
-		this.validateField = this.validateField.bind(this)
-		this.errorClass = this.errorClass.bind(this)
+  constructor(props) {
+    super(props)
+    this.onChange = this.onChange.bind(this)
+    this.onCategoryChange = this.onCategoryChange.bind(this)
+    this.onSubmit = this.onSubmit.bind(this)
+    this.validateField = this.validateField.bind(this)
+    this.errorClass = this.errorClass.bind(this)
 
-		this.state = {
-			cat_info: {},
-			description: '',
-			type: '',
-			servings: 0,
-			vegetarian: false,
-			vegan: false,
-			gluten_free: false,
-			volunteer_name: '',
-			volunteer_phone: '',
-			volunteer_email: '',
-			errors: {
-				type: '',
-				description: '',
-				servings: '',
-				volunteer_name: '',
-				volunteer_phone: '',
-				volunteer_email: ''
-			},
-			messageNeeded: false,
-			message: '',
-			disableAll: false,
-			typeValid: false,
-			descriptionValid: false,
-			servingsValid: false,
-			volunteer_nameValid: false,
-			volunteer_phoneValid: false,
-			volunteer_emailValid: false,
-			formValid: false
-		}
-	}
+    this.state = {
+      cat_info: {},
+      description: '',
+      type: '',
+      servings: 0,
+      vegetarian: false,
+      vegan: false,
+      gluten_free: false,
+      volunteer_name: '',
+      volunteer_phone: '',
+      volunteer_email: '',
+      errors: {
+        type: '',
+        description: '',
+        servings: '',
+        volunteer_name: '',
+        volunteer_phone: '',
+        volunteer_email: ''
+      },
+      messageNeeded: false,
+      message: '',
+      disableAll: false,
+      typeValid: false,
+      descriptionValid: false,
+      servingsValid: false,
+      volunteer_nameValid: false,
+      volunteer_phoneValid: false,
+      volunteer_emailValid: false,
+      formValid: false
+    }
+  }
 
 	clearForm = () => {
-		this.setState({
-			description: '',
-			type: '',
-			servings: 0,
-			vegetarian: false,
-			vegan: false,
-			gluten_free: false,
-			volunteer_name: '',
-			volunteer_phone: '',
-			volunteer_email: '',
-			errors: {
-				type: '',
-				description: '',
-				servings: '',
-				volunteer_name: '',
-				volunteer_phone: '',
-				volunteer_email: ''
-			},
-			messageNeeded: false,
-			message: '',
-			disableAll: false,
-			typeValid: false,
-			descriptionValid: false,
-			servingsValid: false,
-			volunteer_nameValid: false,
-			volunteer_phoneValid: false,
-			volunteer_emailValid: false,
-			formValid: false
-		})
+	  this.setState({
+	    description: '',
+	    type: '',
+	    servings: 0,
+	    vegetarian: false,
+	    vegan: false,
+	    gluten_free: false,
+	    volunteer_name: '',
+	    volunteer_phone: '',
+	    volunteer_email: '',
+	    errors: {
+	      type: '',
+	      description: '',
+	      servings: '',
+	      volunteer_name: '',
+	      volunteer_phone: '',
+	      volunteer_email: ''
+	    },
+	    messageNeeded: false,
+	    message: '',
+	    disableAll: false,
+	    typeValid: false,
+	    descriptionValid: false,
+	    servingsValid: false,
+	    volunteer_nameValid: false,
+	    volunteer_phoneValid: false,
+	    volunteer_emailValid: false,
+	    formValid: false
+	  })
 	}
 
 	onSubmit = (e) => {
-		e.preventDefault()
-		this.props.onSubmit(this.state)
-		this.clearForm()
+	  e.preventDefault()
+	  this.props.onSubmit(this.state)
+	  this.clearForm()
 	}
 
 	updateCheckbox = (event, data) => {
-		this.setState({ [data.name]: data.checked }, this.validateForm)
+	  this.setState({ [data.name]: data.checked }, this.validateForm)
 	}
 
 	onChange = (event, data) => {
-		this.setState({ [data.name]: data.value }, () => {
-			this.validateField(data.name, data.value)
-		})
+	  this.setState({ [data.name]: data.value }, () => {
+	    this.validateField(data.name, data.value)
+	  })
 	}
 
 	onCategoryChange = (event, data) => {
-		this.clearForm()
-		let temp = data.options.find((elem) => {
-			return elem.key === data.value
-		})
-		this.validateField('type', data.value)
-		this.setState({ type: data.value, cat_info: temp.data }, this.validateForm)
+	  this.clearForm()
+	  let temp = data.options.find((elem) => {
+	    return elem.key === data.value
+	  })
+	  this.validateField('type', data.value)
+	  this.setState({ type: data.value, cat_info: temp.data }, this.validateForm)
 	}
 
 	validateField(fieldName, value) {
-		let errors = this.state.errors
-		let typeValid = this.state.typeValid
-		let servingsValid = this.state.servingsValid
-		let volunteer_nameValid = this.state.volunteer_nameValid
-		let volunteer_phoneValid = this.state.volunteer_phoneValid
-		let volunteer_emailValid = this.state.volunteer_emailValid
-		let descriptionValid = this.state.descriptionValid
+	  let errors = this.state.errors
+	  let typeValid = this.state.typeValid
+	  let servingsValid = this.state.servingsValid
+	  let volunteer_nameValid = this.state.volunteer_nameValid
+	  let volunteer_phoneValid = this.state.volunteer_phoneValid
+	  let volunteer_emailValid = this.state.volunteer_emailValid
+	  let descriptionValid = this.state.descriptionValid
 
-		let min_servings = this.state.vegan ? this.state.cat_info.min_vegan_servings : this.state.cat_info.min_servings
+	  let min_servings = this.state.vegan ? this.state.cat_info.min_vegan_servings : this.state.cat_info.min_servings
 
-		switch (fieldName) {
-			case 'type':
-				typeValid = value
-				errors.type = typeValid ? '' : ' ✗ Please select a type'
-				break
-			case 'description':
-				descriptionValid = value.length >= 5
-				errors.description = descriptionValid ? '' : ' ✗ Message must be longer than five characters.'
-				break
-			case 'servings':
-				servingsValid = value >= min_servings && value <= this.props.max_servings
-				errors.servings = servingsValid
-					? ''
-					: ' ✗ Please enter a vaild number between ' + min_servings + '~' + this.props.max_servings + '.'
-				break
-			case 'volunteer_name':
-				volunteer_nameValid = value.length > 2
-				errors.volunteer_name = volunteer_nameValid ? '' : ' ✗ Please enter a vaild Name.'
-				break
-			case 'volunteer_phone':
-				volunteer_phoneValid = value.match(/^[(]?[0-9]{3}[)]?[-]?[0-9]{3}[-]?[0-9]{4}$/i)
-				errors.volunteer_phone = volunteer_phoneValid ? '' : ' ✗ Please enter a vaild phone number.'
-				break
-			case 'volunteer_email':
-				volunteer_emailValid = value.match(/^([\w.%+-]+)@([\w-]+\.)+([\w]{2,})$/i)
-				errors.volunteer_email = volunteer_emailValid ? '' : ' ✗ Please enter a valid email.'
-				break
-			default:
-				break
-		}
+	  switch (fieldName) {
+	  case 'type':
+	    typeValid = value
+	    errors.type = typeValid ? '' : ' ✗ Please select a type'
+	    break
+	  case 'description':
+	    descriptionValid = value.length >= 5
+	    errors.description = descriptionValid ? '' : ' ✗ Message must be longer than five characters.'
+	    break
+	  case 'servings':
+	    servingsValid = value >= min_servings && value <= this.props.max_servings
+	    errors.servings = servingsValid
+	      ? ''
+	      : ' ✗ Please enter a vaild number between ' + min_servings + '~' + this.props.max_servings + '.'
+	    break
+	  case 'volunteer_name':
+	    volunteer_nameValid = value.length > 2
+	    errors.volunteer_name = volunteer_nameValid ? '' : ' ✗ Please enter a vaild Name.'
+	    break
+	  case 'volunteer_phone':
+	    volunteer_phoneValid = value.match(/^[(]?[0-9]{3}[)]?[-]?[0-9]{3}[-]?[0-9]{4}$/i)
+	    errors.volunteer_phone = volunteer_phoneValid ? '' : ' ✗ Please enter a vaild phone number.'
+	    break
+	  case 'volunteer_email':
+	    volunteer_emailValid = value.match(/^([\w.%+-]+)@([\w-]+\.)+([\w]{2,})$/i)
+	    errors.volunteer_email = volunteer_emailValid ? '' : ' ✗ Please enter a valid email.'
+	    break
+	  default:
+	    break
+	  }
 
-		this.setState(
-			{
-				errors,
-				typeValid,
-				servingsValid,
-				volunteer_nameValid,
-				volunteer_phoneValid,
-				volunteer_emailValid,
-				descriptionValid
-			},
-			this.validateForm
-		)
+	  this.setState(
+	    {
+	      errors,
+	      typeValid,
+	      servingsValid,
+	      volunteer_nameValid,
+	      volunteer_phoneValid,
+	      volunteer_emailValid,
+	      descriptionValid
+	    },
+	    this.validateForm
+	  )
 	}
 
 	validateForm() {
-		let numVeganNeeded = this.state.cat_info.food
-			? this.state.cat_info.min_vegan - this.state.cat_info.real_vegan
-			: 0
-		let formValid =
+	  let numVeganNeeded = this.state.cat_info.food
+	    ? this.state.cat_info.min_vegan - this.state.cat_info.real_vegan
+	    : 0
+	  let formValid =
 			this.state.typeValid &&
 			this.state.servingsValid &&
 			this.state.volunteer_nameValid &&
@@ -168,189 +168,189 @@ export default class Item extends Component {
 			this.state.volunteer_emailValid &&
 			this.state.descriptionValid
 
-		if (this.state.cat_info.real_signups >= this.state.cat_info.max_signups) {
-			this.setState({
-				formValid,
-				message:
+	  if (this.state.cat_info.real_signups >= this.state.cat_info.max_signups) {
+	    this.setState({
+	      formValid,
+	      message:
 					'Sorry, but this course is full up on signups. Please consider volunteering for another category!\n',
-				messageNeeded: true,
-				disableAll: true
-			})
-		} else if (
-			this.state.cat_info.food &&
+	      messageNeeded: true,
+	      disableAll: true
+	    })
+	  } else if (
+	    this.state.cat_info.food &&
 			this.state.cat_info.real_signups + numVeganNeeded === this.state.cat_info.max_signups &&
 			!this.state.vegan
-		) {
-			this.setState({
-				formValid,
-				message: 'Signups for this category are limited to Vegan options only.\n',
-				messageNeeded: true
-			})
-		} else {
-			this.setState({
-				formValid,
-				messageNeeded: false
-			})
-		}
+	  ) {
+	    this.setState({
+	      formValid,
+	      message: 'Signups for this category are limited to Vegan options only.\n',
+	      messageNeeded: true
+	    })
+	  } else {
+	    this.setState({
+	      formValid,
+	      messageNeeded: false
+	    })
+	  }
 	}
 
 	errorClass(error) {
-		return error.length === 0 ? '' : 'has-error'
+	  return error.length === 0 ? '' : 'has-error'
 	}
 
 	render() {
-		let options = this.props.event_info.map((category) => {
-			return {
-				key: category.type,
-				text: category.type,
-				value: category.type,
-				data: category
-			}
-		})
+	  let options = this.props.event_info.map((category) => {
+	    return {
+	      key: category.type,
+	      text: category.type,
+	      value: category.type,
+	      data: category
+	    }
+	  })
 
-		let disableSubmit = this.state.messageNeeded
+	  let disableSubmit = this.state.messageNeeded
 
-		return (
-			<div>
-				{this.state.messageNeeded && <Header as="h3">{this.state.message}</Header>}
-				<Segment>
-					<Form onSubmit={this.onSubmit}>
-						<br />
+	  return (
+	    <div>
+	      {this.state.messageNeeded && <Header as="h3">{this.state.message}</Header>}
+	      <Segment>
+	        <Form onSubmit={this.onSubmit}>
+	          <br />
 
-						<div className={`input-wrapper ${this.errorClass(this.state.errors.type)}`}>
-							<b>Please select a type:</b>
-							<Form.Group inline>
-								<Form.Input>
-									<Dropdown
-										name="type"
-										value={this.state.type}
-										onChange={this.onCategoryChange}
-										placeholder="type"
-										fluid
-										selection
-										style={{ width: '370px' }}
-										options={options}
-										label="Select a type:"
-									/>
-								</Form.Input>
-								<div>
-									<span>{this.state.errors.type || ' ✓'}</span>
-								</div>
-							</Form.Group>
-						</div>
-						<br />
+	          <div className={`input-wrapper ${this.errorClass(this.state.errors.type)}`}>
+	            <b>Please select a type:</b>
+	            <Form.Group inline>
+	              <Form.Input>
+	                <Dropdown
+	                  name="type"
+	                  value={this.state.type}
+	                  onChange={this.onCategoryChange}
+	                  placeholder="type"
+	                  fluid
+	                  selection
+	                  style={{ width: '370px' }}
+	                  options={options}
+	                  label="Select a type:"
+	                />
+	              </Form.Input>
+	              <div>
+	                <span>{this.state.errors.type || ' ✓'}</span>
+	              </div>
+	            </Form.Group>
+	          </div>
+	          <br />
 
-						<div className={`input-wrapper ${this.errorClass(this.state.errors.description)}`}>
-							<Form.Group inline>
-								<Form.Input
-									name="description"
-									value={this.state.description}
-									onChange={this.onChange}
-									style={{ width: '370px' }}
-									label="Item"
-									placeholder="description"
-									disabled={this.state.disableAll}
-								/>
-								<div>
-									<span>{this.state.errors.description || ' ✓'}</span>
-								</div>
-							</Form.Group>
-						</div>
-						<br />
-						{this.state.cat_info.food && (
-							<div>
-								<Form.Group>
-									<Form.Checkbox
-										onChange={this.updateCheckbox}
-										checked={this.state.vegan}
-										name="vegan"
-										label="Vegan"
-										disabled={this.state.disableAll}
-									/>
-									<Form.Checkbox
-										onChange={this.updateCheckbox}
-										checked={this.state.vegetarian}
-										name="vegetarian"
-										label="Vegetarian"
-										disabled={this.state.disableAll}
-									/>
-									<Form.Checkbox
-										onChange={this.updateCheckbox}
-										checked={this.state.gluten_free}
-										name="gluten_free"
-										label="Gluten-free"
-										disabled={this.state.disableAll}
-									/>
-								</Form.Group>
-								<br />
-							</div>
-						)}
+	          <div className={`input-wrapper ${this.errorClass(this.state.errors.description)}`}>
+	            <Form.Group inline>
+	              <Form.Input
+	                name="description"
+	                value={this.state.description}
+	                onChange={this.onChange}
+	                style={{ width: '370px' }}
+	                label="Item"
+	                placeholder="description"
+	                disabled={this.state.disableAll}
+	              />
+	              <div>
+	                <span>{this.state.errors.description || ' ✓'}</span>
+	              </div>
+	            </Form.Group>
+	          </div>
+	          <br />
+	          {this.state.cat_info.food && (
+	            <div>
+	              <Form.Group>
+	                <Form.Checkbox
+	                  onChange={this.updateCheckbox}
+	                  checked={this.state.vegan}
+	                  name="vegan"
+	                  label="Vegan"
+	                  disabled={this.state.disableAll}
+	                />
+	                <Form.Checkbox
+	                  onChange={this.updateCheckbox}
+	                  checked={this.state.vegetarian}
+	                  name="vegetarian"
+	                  label="Vegetarian"
+	                  disabled={this.state.disableAll}
+	                />
+	                <Form.Checkbox
+	                  onChange={this.updateCheckbox}
+	                  checked={this.state.gluten_free}
+	                  name="gluten_free"
+	                  label="Gluten-free"
+	                  disabled={this.state.disableAll}
+	                />
+	              </Form.Group>
+	              <br />
+	            </div>
+	          )}
 
-						<Form.Group inline>
-							<div className={`input-wrapper ${this.errorClass(this.state.errors.servings)}`}>
-								<Form.Group inline>
-									<Form.Input
-										name="servings"
-										value={this.state.servings}
-										onChange={this.onChange}
-										inline
-										label="Servings"
-										disabled={this.state.disableAll}
-									/>
-									<div>
-										<span>{this.state.errors.servings || ' ✓'}</span>
-									</div>
-								</Form.Group>
-							</div>
-						</Form.Group>
+	          <Form.Group inline>
+	            <div className={`input-wrapper ${this.errorClass(this.state.errors.servings)}`}>
+	              <Form.Group inline>
+	                <Form.Input
+	                  name="servings"
+	                  value={this.state.servings}
+	                  onChange={this.onChange}
+	                  inline
+	                  label="Servings"
+	                  disabled={this.state.disableAll}
+	                />
+	                <div>
+	                  <span>{this.state.errors.servings || ' ✓'}</span>
+	                </div>
+	              </Form.Group>
+	            </div>
+	          </Form.Group>
 
-						<Form.Group widths="equal">
-							<div className={`input-wrapper ${this.errorClass(this.state.errors.volunteer_name)}`}>
-								<Form.Input
-									name="volunteer_name"
-									value={this.state.volunteer_name}
-									onChange={this.onChange}
-									label="Name"
-									placeholder=" John"
-									disabled={this.state.disableAll}
-								/>
-								<span>{this.state.errors.volunteer_name || ' ✓'}</span>
-							</div>
+	          <Form.Group widths="equal">
+	            <div className={`input-wrapper ${this.errorClass(this.state.errors.volunteer_name)}`}>
+	              <Form.Input
+	                name="volunteer_name"
+	                value={this.state.volunteer_name}
+	                onChange={this.onChange}
+	                label="Name"
+	                placeholder=" John"
+	                disabled={this.state.disableAll}
+	              />
+	              <span>{this.state.errors.volunteer_name || ' ✓'}</span>
+	            </div>
 
-							<div className={`input-wrapper ${this.errorClass(this.state.errors.volunteer_email)}`}>
-								<Form.Input
-									name="volunteer_email"
-									value={this.state.volunteer_email}
-									onChange={this.onChange}
-									label="Email"
-									placeholder=" xxxx@gmail.com"
-									disabled={this.state.disableAll}
-								/>
-								<span>{this.state.errors.volunteer_email || ' ✓'}</span>
-							</div>
+	            <div className={`input-wrapper ${this.errorClass(this.state.errors.volunteer_email)}`}>
+	              <Form.Input
+	                name="volunteer_email"
+	                value={this.state.volunteer_email}
+	                onChange={this.onChange}
+	                label="Email"
+	                placeholder=" xxxx@gmail.com"
+	                disabled={this.state.disableAll}
+	              />
+	              <span>{this.state.errors.volunteer_email || ' ✓'}</span>
+	            </div>
 
-							<div className={`input-wrapper ${this.errorClass(this.state.errors.volunteer_phone)}`}>
-								<Form.Input
-									name="volunteer_phone"
-									value={this.state.volunteer_phone}
-									onChange={this.onChange}
-									label="Phone"
-									placeholder=" xxx-xxx-xxxx"
-									disabled={this.state.disableAll}
-								/>
-								<span>{this.state.errors.volunteer_phone || ' ✓'}</span>
-							</div>
-						</Form.Group>
+	            <div className={`input-wrapper ${this.errorClass(this.state.errors.volunteer_phone)}`}>
+	              <Form.Input
+	                name="volunteer_phone"
+	                value={this.state.volunteer_phone}
+	                onChange={this.onChange}
+	                label="Phone"
+	                placeholder=" xxx-xxx-xxxx"
+	                disabled={this.state.disableAll}
+	              />
+	              <span>{this.state.errors.volunteer_phone || ' ✓'}</span>
+	            </div>
+	          </Form.Group>
 
-						<Button
-							color="green"
-							disabled={!this.state.formValid || disableSubmit || this.state.disableAll}
-						>
+	          <Button
+	            color="green"
+	            disabled={!this.state.formValid || disableSubmit || this.state.disableAll}
+	          >
 							Submit
-						</Button>
-					</Form>
-				</Segment>
-			</div>
-		)
+	          </Button>
+	        </Form>
+	      </Segment>
+	    </div>
+	  )
 	}
 }

--- a/packages/ui/src/Components/Volunteer/VolunteerForm.js
+++ b/packages/ui/src/Components/Volunteer/VolunteerForm.js
@@ -10,9 +10,10 @@ export default class VolunteerForm extends Component {
     super(props)
 
     let params = new URLSearchParams(this.props.location.search)
-    if (params.get("date") === null) {
+    if (params.get('date') === null) {
       params.append('date', new Moment().format('MM-DD-YY'))
     }
+    // dum dee dum test test
     this.state = {
       validEvent: true,
       date: params.get('date'),

--- a/packages/ui/src/Components/Volunteer/VolunteerForm.js
+++ b/packages/ui/src/Components/Volunteer/VolunteerForm.js
@@ -13,7 +13,6 @@ export default class VolunteerForm extends Component {
     if (params.get('date') === null) {
       params.append('date', new Moment().format('MM-DD-YY'))
     }
-    // dum dee dum test test
     this.state = {
       validEvent: true,
       date: params.get('date'),

--- a/packages/ui/src/Components/Volunteer/VolunteerForm.js
+++ b/packages/ui/src/Components/Volunteer/VolunteerForm.js
@@ -6,91 +6,91 @@ import Axios from 'axios'
 import Moment from 'moment'
 
 export default class VolunteerForm extends Component {
-	constructor(props) {
-		super(props)
+  constructor(props) {
+    super(props)
 
-		let params = new URLSearchParams(this.props.location.search)
-		if (params.get('date') === null) {
-			params.append('date', new Moment().format('MM-DD-YY'))
-		}
-		this.state = {
-			validEvent: true,
-			date: params.get('date'),
-			coordinator: '',
-			coordinator_phone: '',
-			location: '',
-			event_info: [ { type: 'n/a', servings: 0 } ],
-			max_servings: 0
-		}
-	}
+    let params = new URLSearchParams(this.props.location.search)
+    if (params.get("date") === null) {
+      params.append('date', new Moment().format('MM-DD-YY'))
+    }
+    this.state = {
+      validEvent: true,
+      date: params.get('date'),
+      coordinator: '',
+      coordinator_phone: '',
+      location: '',
+      event_info: [ { type: 'n/a', servings: 0 } ],
+      max_servings: 0
+    }
+  }
 
 	onSubmit = (data) => {
-		data.date = this.state.date
-		Axios.post('/api/form', data)
-			.then((response) => {
-				console.log(response, 'Form Submitted')
-			})
-			.catch((err) => {
-				console.log(err, 'Try again.')
-			})
-		window.location.reload()
+	  data.date = this.state.date
+	  Axios.post('/api/form', data)
+	    .then((response) => {
+	      console.log(response, 'Form Submitted')
+	    })
+	    .catch((err) => {
+	      console.log(err, 'Try again.')
+	    })
+	  window.location.reload()
 	}
 
 	async componentDidMount() {
-		if (!this.state.date.match(/^((0[1-9])|(1[0-2])){1}-(0[1-9]|[1-2][0-9]|3[0-1]){1}-(19|[2-3][0-9]){1}$/)) {
-			this.setState({ validEvent: false })
-		} else {
-			let path = '/api/event?date=' + this.state.date
-			Axios.get(path)
-				.then((res) => {
-					if (res.data.status === 'SUCCESS') {
-						let categories = []
-						if (res.data['event_info']) {
-							let data = JSON.parse(res.data['event_info'])
-							data.map((category) => categories.push(category))
-							this.setState({
-								event_info: categories,
-								location: res.data.location,
-								coordinator: res.data.coordinator,
-								coordinator_phone: res.data.coordinator_phone,
-								max_servings: res.data.max_servings
-							})
-						} else {
-							throw new Error('Successful GET request, but no data')
-						}
-					} else {
-						this.setState({ validEvent: false })
-					}
-				})
-				.catch((err) => {
-					this.setState({ validEvent: false })
-					console.log(err, 'Error Retrieving Event Information')
-				})
-		}
+	  if (!this.state.date.match(/^((0[1-9])|(1[0-2])){1}-(0[1-9]|[1-2][0-9]|3[0-1]){1}-(19|[2-3][0-9]){1}$/)) {
+	    this.setState({ validEvent: false })
+	  } else {
+	    let path = '/api/event?date=' + this.state.date
+	    Axios.get(path)
+	      .then((res) => {
+	        if (res.data.status === 'SUCCESS') {
+	          let categories = []
+	          if (res.data['event_info']) {
+	            let data = JSON.parse(res.data['event_info'])
+	            data.map((category) => categories.push(category))
+	            this.setState({
+	              event_info: categories,
+	              location: res.data.location,
+	              coordinator: res.data.coordinator,
+	              coordinator_phone: res.data.coordinator_phone,
+	              max_servings: res.data.max_servings
+	            })
+	          } else {
+	            throw new Error('Successful GET request, but no data')
+	          }
+	        } else {
+	          this.setState({ validEvent: false })
+	        }
+	      })
+	      .catch((err) => {
+	        this.setState({ validEvent: false })
+	        console.log(err, 'Error Retrieving Event Information')
+	      })
+	  }
 	}
 
 	render() {
-		return (
-			<div>
-				{this.state.validEvent ? (
-					<Container>
-						<Header as="h2" style={{ marginTop: '20px' }}>
+	  return (
+	    <div>
+	      {this.state.validEvent ? (
+	        <Container>
+	          <Header as="h2" style={{ marginTop: '20px' }}>
 							Dinner Sign-Up{' '}
-						</Header>
-						<Header as="h2">Volunteer Coordinator: {this.state.coordinator}</Header>
-						<Header as="h2">Volunteer Coordinator Phone: {this.state.coordinator_phone}</Header>
-						<Header as="h2">Location: {this.state.location}</Header>
-						<Header as="h2">Date: {this.state.date} </Header>
-						<Item
-							onSubmit={this.onSubmit}
-							event_info={this.state.event_info}
-							max_servings={this.state.max_servings}
-						/>
-					</Container>
-				) : (
-					<Redirect to="/" />
-				)}
-			</div>
-		)
+	          </Header>
+	          <Header as="h2">Volunteer Coordinator: {this.state.coordinator}</Header>
+	          <Header as="h2">Volunteer Coordinator Phone: {this.state.coordinator_phone}</Header>
+	          <Header as="h2">Location: {this.state.location}</Header>
+	          <Header as="h2">Date: {this.state.date} </Header>
+	          <Item
+	            onSubmit={this.onSubmit}
+	            event_info={this.state.event_info}
+	            max_servings={this.state.max_servings}
+	          />
+	        </Container>
+	      ) : (
+	        <Redirect to="/" />
+	      )}
+	    </div>
+	  )
 	}
 }

--- a/packages/ui/src/Components/Volunteer/VolunteerForm.js
+++ b/packages/ui/src/Components/Volunteer/VolunteerForm.js
@@ -9,7 +9,7 @@ export default class VolunteerForm extends Component {
   constructor(props) {
     super(props)
 
-    let params = new URLSearchParams(this.props.location.search)
+    	let params = new URLSearchParams(this.props.location.search)
     if (params.get('date') === null) {
       params.append('date', new Moment().format('MM-DD-YY'))
     }

--- a/packages/ui/yarn.lock
+++ b/packages/ui/yarn.lock
@@ -29,18 +29,18 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/core@^7.1.6":
-  version "7.3.3"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.3.3.tgz#d090d157b7c5060d05a05acaebc048bd2b037947"
-  integrity sha512-w445QGI2qd0E0GlSnq6huRZWPMmQGCp5gd5ZWS4hagn0EiwzxD5QMFkpchyusAyVC1n27OKXzQ0/88aVU9n4xQ==
+"@babel/core@^7.1.6", "@babel/core@^7.4.3":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.4.4.tgz#84055750b05fcd50f9915a826b44fa347a825250"
+  integrity sha512-lQgGX3FPRgbz2SKmhMtYgJvVzGZrmjaF4apZ2bLwofAKiSjxU0drPh4S/VasyYXwaTs+A1gvQ45BN8SQJzHsQQ==
   dependencies:
     "@babel/code-frame" "^7.0.0"
-    "@babel/generator" "^7.3.3"
-    "@babel/helpers" "^7.2.0"
-    "@babel/parser" "^7.3.3"
-    "@babel/template" "^7.2.2"
-    "@babel/traverse" "^7.2.2"
-    "@babel/types" "^7.3.3"
+    "@babel/generator" "^7.4.4"
+    "@babel/helpers" "^7.4.4"
+    "@babel/parser" "^7.4.4"
+    "@babel/template" "^7.4.4"
+    "@babel/traverse" "^7.4.4"
+    "@babel/types" "^7.4.4"
     convert-source-map "^1.1.0"
     debug "^4.1.0"
     json5 "^2.1.0"
@@ -49,12 +49,12 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/generator@^7.2.2", "@babel/generator@^7.3.3":
-  version "7.3.3"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.3.3.tgz#185962ade59a52e00ca2bdfcfd1d58e528d4e39e"
-  integrity sha512-aEADYwRRZjJyMnKN7llGIlircxTCofm3dtV5pmY6ob18MSIuipHpA2yZWkPlycwu5HJcx/pADS3zssd8eY7/6A==
+"@babel/generator@^7.2.2", "@babel/generator@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.4.4.tgz#174a215eb843fc392c7edcaabeaa873de6e8f041"
+  integrity sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==
   dependencies:
-    "@babel/types" "^7.3.3"
+    "@babel/types" "^7.4.4"
     jsesc "^2.5.1"
     lodash "^4.17.11"
     source-map "^0.5.0"
@@ -83,34 +83,35 @@
     "@babel/types" "^7.3.0"
     esutils "^2.0.0"
 
-"@babel/helper-call-delegate@^7.1.0":
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-call-delegate/-/helper-call-delegate-7.1.0.tgz#6a957f105f37755e8645343d3038a22e1449cc4a"
-  integrity sha512-YEtYZrw3GUK6emQHKthltKNZwszBcHK58Ygcis+gVUrF4/FmTVr5CCqQNSfmvg2y+YDEANyYoaLz/SHsnusCwQ==
+"@babel/helper-call-delegate@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-call-delegate/-/helper-call-delegate-7.4.4.tgz#87c1f8ca19ad552a736a7a27b1c1fcf8b1ff1f43"
+  integrity sha512-l79boDFJ8S1c5hvQvG+rc+wHw6IuH7YldmRKsYtpbawsxURu/paVy57FZMomGK22/JckepaikOkY0MoAmdyOlQ==
   dependencies:
-    "@babel/helper-hoist-variables" "^7.0.0"
-    "@babel/traverse" "^7.1.0"
-    "@babel/types" "^7.0.0"
+    "@babel/helper-hoist-variables" "^7.4.4"
+    "@babel/traverse" "^7.4.4"
+    "@babel/types" "^7.4.4"
 
 "@babel/helper-create-class-features-plugin@^7.3.0":
-  version "7.3.2"
-  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.3.2.tgz#ba1685603eb1c9f2f51c9106d5180135c163fe73"
-  integrity sha512-tdW8+V8ceh2US4GsYdNVNoohq5uVwOf9k6krjwW4E1lINcHgttnWcNqgdoessn12dAy8QkbezlbQh2nXISNY+A==
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.4.4.tgz#fc3d690af6554cc9efc607364a82d48f58736dba"
+  integrity sha512-UbBHIa2qeAGgyiNR9RszVF7bUHEdgS4JAUNT8SiqrAN6YJVxlOxeLr5pBzb5kan302dejJ9nla4RyKcR1XT6XA==
   dependencies:
     "@babel/helper-function-name" "^7.1.0"
     "@babel/helper-member-expression-to-functions" "^7.0.0"
     "@babel/helper-optimise-call-expression" "^7.0.0"
     "@babel/helper-plugin-utils" "^7.0.0"
-    "@babel/helper-replace-supers" "^7.2.3"
+    "@babel/helper-replace-supers" "^7.4.4"
+    "@babel/helper-split-export-declaration" "^7.4.4"
 
-"@babel/helper-define-map@^7.1.0":
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-define-map/-/helper-define-map-7.1.0.tgz#3b74caec329b3c80c116290887c0dd9ae468c20c"
-  integrity sha512-yPPcW8dc3gZLN+U1mhYV91QU3n5uTbx7DUdf8NnPbjS0RMwBuHi9Xt2MUgppmNz7CJxTBWsGczTiEp1CSOTPRg==
+"@babel/helper-define-map@^7.1.0", "@babel/helper-define-map@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-define-map/-/helper-define-map-7.4.4.tgz#6969d1f570b46bdc900d1eba8e5d59c48ba2c12a"
+  integrity sha512-IX3Ln8gLhZpSuqHJSnTNBWGDE9kdkTEWl21A/K7PQ00tseBwbqCHTvNLHSBd9M0R5rER4h5Rsvj9vw0R5SieBg==
   dependencies:
     "@babel/helper-function-name" "^7.1.0"
-    "@babel/types" "^7.0.0"
-    lodash "^4.17.10"
+    "@babel/types" "^7.4.4"
+    lodash "^4.17.11"
 
 "@babel/helper-explode-assignable-expression@^7.1.0":
   version "7.1.0"
@@ -136,12 +137,12 @@
   dependencies:
     "@babel/types" "^7.0.0"
 
-"@babel/helper-hoist-variables@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0.tgz#46adc4c5e758645ae7a45deb92bab0918c23bb88"
-  integrity sha512-Ggv5sldXUeSKsuzLkddtyhyHe2YantsxWKNi7A+7LeD12ExRDWTRk29JCXpaHPAbMaIPZSil7n+lq78WY2VY7w==
+"@babel/helper-hoist-variables@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.4.4.tgz#0298b5f25c8c09c53102d52ac4a98f773eb2850a"
+  integrity sha512-VYk2/H/BnYbZDDg39hr3t2kKyifAm1W6zHRfhx8jGjIHpQEBv9dry7oQ2f3+J703TLu69nYdxsovl0XYfcnK4w==
   dependencies:
-    "@babel/types" "^7.0.0"
+    "@babel/types" "^7.4.4"
 
 "@babel/helper-member-expression-to-functions@^7.0.0":
   version "7.0.0"
@@ -157,17 +158,17 @@
   dependencies:
     "@babel/types" "^7.0.0"
 
-"@babel/helper-module-transforms@^7.1.0":
-  version "7.2.2"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.2.2.tgz#ab2f8e8d231409f8370c883d20c335190284b963"
-  integrity sha512-YRD7I6Wsv+IHuTPkAmAS4HhY0dkPobgLftHp0cRGZSdrRvmZY8rFvae/GVu3bD00qscuvK3WPHB3YdNpBXUqrA==
+"@babel/helper-module-transforms@^7.1.0", "@babel/helper-module-transforms@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.4.4.tgz#96115ea42a2f139e619e98ed46df6019b94414b8"
+  integrity sha512-3Z1yp8TVQf+B4ynN7WoHPKS8EkdTbgAEy0nU0rs/1Kw4pDgmvYH3rz3aI11KgxKCba2cn7N+tqzV1mY2HMN96w==
   dependencies:
     "@babel/helper-module-imports" "^7.0.0"
     "@babel/helper-simple-access" "^7.1.0"
-    "@babel/helper-split-export-declaration" "^7.0.0"
-    "@babel/template" "^7.2.2"
-    "@babel/types" "^7.2.2"
-    lodash "^4.17.10"
+    "@babel/helper-split-export-declaration" "^7.4.4"
+    "@babel/template" "^7.4.4"
+    "@babel/types" "^7.4.4"
+    lodash "^4.17.11"
 
 "@babel/helper-optimise-call-expression@^7.0.0":
   version "7.0.0"
@@ -181,12 +182,12 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz#bbb3fbee98661c569034237cc03967ba99b4f250"
   integrity sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==
 
-"@babel/helper-regex@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-regex/-/helper-regex-7.0.0.tgz#2c1718923b57f9bbe64705ffe5640ac64d9bdb27"
-  integrity sha512-TR0/N0NDCcUIUEbqV6dCO+LptmmSQFQ7q70lfcEB4URsjD0E1HzicrwUH+ap6BAQ2jhCX9Q4UqZy4wilujWlkg==
+"@babel/helper-regex@^7.0.0", "@babel/helper-regex@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-regex/-/helper-regex-7.4.4.tgz#a47e02bc91fb259d2e6727c2a30013e3ac13c4a2"
+  integrity sha512-Y5nuB/kESmR3tKjU8Nkn1wMGEx1tjJX076HBMeL3XLQCu6vA/YRzuTW0bbb+qRnXvQGn+d6Rx953yffl8vEy7Q==
   dependencies:
-    lodash "^4.17.10"
+    lodash "^4.17.11"
 
 "@babel/helper-remap-async-to-generator@^7.1.0":
   version "7.1.0"
@@ -199,15 +200,15 @@
     "@babel/traverse" "^7.1.0"
     "@babel/types" "^7.0.0"
 
-"@babel/helper-replace-supers@^7.1.0", "@babel/helper-replace-supers@^7.2.3":
-  version "7.2.3"
-  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.2.3.tgz#19970020cf22677d62b3a689561dbd9644d8c5e5"
-  integrity sha512-GyieIznGUfPXPWu0yLS6U55Mz67AZD9cUk0BfirOWlPrXlBcan9Gz+vHGz+cPfuoweZSnPzPIm67VtQM0OWZbA==
+"@babel/helper-replace-supers@^7.1.0", "@babel/helper-replace-supers@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.4.4.tgz#aee41783ebe4f2d3ab3ae775e1cc6f1a90cefa27"
+  integrity sha512-04xGEnd+s01nY1l15EuMS1rfKktNF+1CkKmHoErDppjAAZL+IUBZpzT748x262HF7fibaQPhbvWUl5HeSt1EXg==
   dependencies:
     "@babel/helper-member-expression-to-functions" "^7.0.0"
     "@babel/helper-optimise-call-expression" "^7.0.0"
-    "@babel/traverse" "^7.2.3"
-    "@babel/types" "^7.0.0"
+    "@babel/traverse" "^7.4.4"
+    "@babel/types" "^7.4.4"
 
 "@babel/helper-simple-access@^7.1.0":
   version "7.1.0"
@@ -217,12 +218,12 @@
     "@babel/template" "^7.1.0"
     "@babel/types" "^7.0.0"
 
-"@babel/helper-split-export-declaration@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz#3aae285c0311c2ab095d997b8c9a94cad547d813"
-  integrity sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==
+"@babel/helper-split-export-declaration@^7.0.0", "@babel/helper-split-export-declaration@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz#ff94894a340be78f53f06af038b205c49d993677"
+  integrity sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==
   dependencies:
-    "@babel/types" "^7.0.0"
+    "@babel/types" "^7.4.4"
 
 "@babel/helper-wrap-function@^7.1.0":
   version "7.2.0"
@@ -234,14 +235,14 @@
     "@babel/traverse" "^7.1.0"
     "@babel/types" "^7.2.0"
 
-"@babel/helpers@^7.2.0":
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.3.1.tgz#949eec9ea4b45d3210feb7dc1c22db664c9e44b9"
-  integrity sha512-Q82R3jKsVpUV99mgX50gOPCWwco9Ec5Iln/8Vyu4osNIOQgSrd9RFrQeUvmvddFNoLwMyOUWU+5ckioEKpDoGA==
+"@babel/helpers@^7.2.0", "@babel/helpers@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.4.4.tgz#868b0ef59c1dd4e78744562d5ce1b59c89f2f2a5"
+  integrity sha512-igczbR/0SeuPR8RFfC7tGrbdTbFL3QTvH6D+Z6zNxnTe//GyqmtHmDkzrqDmyZ3eSwPqB/LhyKoU5DXsp+Vp2A==
   dependencies:
-    "@babel/template" "^7.1.2"
-    "@babel/traverse" "^7.1.5"
-    "@babel/types" "^7.3.0"
+    "@babel/template" "^7.4.4"
+    "@babel/traverse" "^7.4.4"
+    "@babel/types" "^7.4.4"
 
 "@babel/highlight@^7.0.0":
   version "7.0.0"
@@ -252,10 +253,10 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.0.0", "@babel/parser@^7.2.2", "@babel/parser@^7.2.3", "@babel/parser@^7.3.3":
-  version "7.3.3"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.3.3.tgz#092d450db02bdb6ccb1ca8ffd47d8774a91aef87"
-  integrity sha512-xsH1CJoln2r74hR+y7cg2B5JCPaTh+Hd+EbBRk9nWGSNspuo6krjhX0Om6RnRQuIvFq8wVXCLKH3kwKDYhanSg==
+"@babel/parser@^7.0.0", "@babel/parser@^7.2.2", "@babel/parser@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.4.4.tgz#5977129431b8fe33471730d255ce8654ae1250b6"
+  integrity sha512-5pCS4mOsL+ANsFZGdvNLybx4wtqAZJ0MJjMHxvzI3bvIsz6sQvzW8XX92EYIkiPtIvcfG3Aj+Ir5VNyjnZhP7w==
 
 "@babel/plugin-proposal-async-generator-functions@^7.2.0":
   version "7.2.0"
@@ -291,10 +292,18 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-json-strings" "^7.2.0"
 
-"@babel/plugin-proposal-object-rest-spread@7.3.2", "@babel/plugin-proposal-object-rest-spread@^7.3.1":
+"@babel/plugin-proposal-object-rest-spread@7.3.2":
   version "7.3.2"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.3.2.tgz#6d1859882d4d778578e41f82cc5d7bf3d5daf6c1"
   integrity sha512-DjeMS+J2+lpANkYLLO+m6GjoTMygYglKmRe6cDTbFv3L9i6mmiE8fe6B8MtCSLZpVXscD5kn7s6SgtHrDoBWoA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-syntax-object-rest-spread" "^7.2.0"
+
+"@babel/plugin-proposal-object-rest-spread@^7.3.1", "@babel/plugin-proposal-object-rest-spread@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.4.4.tgz#1ef173fcf24b3e2df92a678f027673b55e7e3005"
+  integrity sha512-dMBG6cSPBbHeEBdFXeQ2QLc5gUpg4Vkaz8octD4aoW/ISO+jBOcsuxYL7bsb5WSu8RLP6boxrBIALEHgoHtO9g==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-object-rest-spread" "^7.2.0"
@@ -307,14 +316,14 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-optional-catch-binding" "^7.2.0"
 
-"@babel/plugin-proposal-unicode-property-regex@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.2.0.tgz#abe7281fe46c95ddc143a65e5358647792039520"
-  integrity sha512-LvRVYb7kikuOtIoUeWTkOxQEV1kYvL5B6U3iWEGCzPNRus1MzJweFqORTj+0jkxozkTSYNJozPOddxmqdqsRpw==
+"@babel/plugin-proposal-unicode-property-regex@^7.2.0", "@babel/plugin-proposal-unicode-property-regex@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.4.4.tgz#501ffd9826c0b91da22690720722ac7cb1ca9c78"
+  integrity sha512-j1NwnOqMG9mFUOH58JTFsA/+ZYzQLUZ/drqWUqxCYLGeu2JFZL8YrNC9hBxKmWtAuOCHPcRpgv7fhap09Fb4kA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
-    "@babel/helper-regex" "^7.0.0"
-    regexpu-core "^4.2.0"
+    "@babel/helper-regex" "^7.4.4"
+    regexpu-core "^4.5.4"
 
 "@babel/plugin-syntax-async-generators@^7.2.0":
   version "7.2.0"
@@ -386,10 +395,10 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-transform-async-to-generator@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.2.0.tgz#68b8a438663e88519e65b776f8938f3445b1a2ff"
-  integrity sha512-CEHzg4g5UraReozI9D4fblBYABs7IM6UerAVG7EJVrTLC5keh00aEuLUT+O40+mJCEzaXkYfTCUKIyeDfMOFFQ==
+"@babel/plugin-transform-async-to-generator@^7.2.0", "@babel/plugin-transform-async-to-generator@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.4.4.tgz#a3f1d01f2f21cadab20b33a82133116f14fb5894"
+  integrity sha512-YiqW2Li8TXmzgbXw+STsSqPBPFnGviiaSp6CYOq55X8GQ2SGVLrXB6pNid8HkqkZAzOH6knbai3snhP7v0fNwA==
   dependencies:
     "@babel/helper-module-imports" "^7.0.0"
     "@babel/helper-plugin-utils" "^7.0.0"
@@ -402,13 +411,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-transform-block-scoping@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.2.0.tgz#f17c49d91eedbcdf5dd50597d16f5f2f770132d4"
-  integrity sha512-vDTgf19ZEV6mx35yiPJe4fS02mPQUUcBNwWQSZFXSzTSbsJFQvHt7DqyS3LK8oOWALFOsJ+8bbqBgkirZteD5Q==
+"@babel/plugin-transform-block-scoping@^7.2.0", "@babel/plugin-transform-block-scoping@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.4.4.tgz#c13279fabf6b916661531841a23c4b7dae29646d"
+  integrity sha512-jkTUyWZcTrwxu5DD4rWz6rDB5Cjdmgz6z7M7RLXOJyCUkFBawssDGcGh8M/0FTSB87avyJI1HsTwUXp9nKA1PA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
-    lodash "^4.17.10"
+    lodash "^4.17.11"
 
 "@babel/plugin-transform-classes@7.2.2":
   version "7.2.2"
@@ -424,18 +433,18 @@
     "@babel/helper-split-export-declaration" "^7.0.0"
     globals "^11.1.0"
 
-"@babel/plugin-transform-classes@^7.2.0":
-  version "7.3.3"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-classes/-/plugin-transform-classes-7.3.3.tgz#a0532d6889c534d095e8f604e9257f91386c4b51"
-  integrity sha512-n0CLbsg7KOXsMF4tSTLCApNMoXk0wOPb0DYfsOO1e7SfIb9gOyfbpKI2MZ+AXfqvlfzq2qsflJ1nEns48Caf2w==
+"@babel/plugin-transform-classes@^7.2.0", "@babel/plugin-transform-classes@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-classes/-/plugin-transform-classes-7.4.4.tgz#0ce4094cdafd709721076d3b9c38ad31ca715eb6"
+  integrity sha512-/e44eFLImEGIpL9qPxSRat13I5QNRgBLu2hOQJCF7VLy/otSM/sypV1+XaIw5+502RX/+6YaSAPmldk+nhHDPw==
   dependencies:
     "@babel/helper-annotate-as-pure" "^7.0.0"
-    "@babel/helper-define-map" "^7.1.0"
+    "@babel/helper-define-map" "^7.4.4"
     "@babel/helper-function-name" "^7.1.0"
     "@babel/helper-optimise-call-expression" "^7.0.0"
     "@babel/helper-plugin-utils" "^7.0.0"
-    "@babel/helper-replace-supers" "^7.1.0"
-    "@babel/helper-split-export-declaration" "^7.0.0"
+    "@babel/helper-replace-supers" "^7.4.4"
+    "@babel/helper-split-export-declaration" "^7.4.4"
     globals "^11.1.0"
 
 "@babel/plugin-transform-computed-properties@^7.2.0":
@@ -445,21 +454,28 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-transform-destructuring@7.3.2", "@babel/plugin-transform-destructuring@^7.2.0":
+"@babel/plugin-transform-destructuring@7.3.2":
   version "7.3.2"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.3.2.tgz#f2f5520be055ba1c38c41c0e094d8a461dd78f2d"
   integrity sha512-Lrj/u53Ufqxl/sGxyjsJ2XNtNuEjDyjpqdhMNh5aZ+XFOdThL46KBj27Uem4ggoezSYBxKWAil6Hu8HtwqesYw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-transform-dotall-regex@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.2.0.tgz#f0aabb93d120a8ac61e925ea0ba440812dbe0e49"
-  integrity sha512-sKxnyHfizweTgKZf7XsXu/CNupKhzijptfTM+bozonIuyVrLWVUvYjE2bhuSBML8VQeMxq4Mm63Q9qvcvUcciQ==
+"@babel/plugin-transform-destructuring@^7.2.0", "@babel/plugin-transform-destructuring@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.4.4.tgz#9d964717829cc9e4b601fc82a26a71a4d8faf20f"
+  integrity sha512-/aOx+nW0w8eHiEHm+BTERB2oJn5D127iye/SUQl7NjHy0lf+j7h4MKMMSOwdazGq9OxgiNADncE+SRJkCxjZpQ==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
-    "@babel/helper-regex" "^7.0.0"
-    regexpu-core "^4.1.3"
+
+"@babel/plugin-transform-dotall-regex@^7.2.0", "@babel/plugin-transform-dotall-regex@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.4.4.tgz#361a148bc951444312c69446d76ed1ea8e4450c3"
+  integrity sha512-P05YEhRc2h53lZDjRPk/OektxCVevFzZs2Gfjd545Wde3k+yFDbXORgl2e0xpbq8mLcKJ7Idss4fAg0zORN/zg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-regex" "^7.4.4"
+    regexpu-core "^4.5.4"
 
 "@babel/plugin-transform-duplicate-keys@^7.2.0":
   version "7.2.0"
@@ -484,17 +500,17 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-flow" "^7.2.0"
 
-"@babel/plugin-transform-for-of@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.2.0.tgz#ab7468befa80f764bb03d3cb5eef8cc998e1cad9"
-  integrity sha512-Kz7Mt0SsV2tQk6jG5bBv5phVbkd0gd27SgYD4hH1aLMJRchM0dzHaXvrWhVZ+WxAlDoAKZ7Uy3jVTW2mKXQ1WQ==
+"@babel/plugin-transform-for-of@^7.2.0", "@babel/plugin-transform-for-of@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.4.4.tgz#0267fc735e24c808ba173866c6c4d1440fc3c556"
+  integrity sha512-9T/5Dlr14Z9TIEXLXkt8T1DU7F24cbhwhMNUziN3hB1AXoZcdzPcTiKGRn/6iOymDqtTKWnr/BtRKN9JwbKtdQ==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-transform-function-name@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.2.0.tgz#f7930362829ff99a3174c39f0afcc024ef59731a"
-  integrity sha512-kWgksow9lHdvBC2Z4mxTsvc7YdY7w/V6B2vy9cTIPtLEE9NhwoWivaxdNM/S37elu5bqlLP/qOY906LukO9lkQ==
+"@babel/plugin-transform-function-name@^7.2.0", "@babel/plugin-transform-function-name@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.4.4.tgz#e1436116abb0610c2259094848754ac5230922ad"
+  integrity sha512-iU9pv7U+2jC9ANQkKeNF6DrPy4GBa4NWQtl6dHB4Pb3izX2JOEvDTFarlNsBj/63ZEzNNIAMs3Qw4fNCcSOXJA==
   dependencies:
     "@babel/helper-function-name" "^7.1.0"
     "@babel/helper-plugin-utils" "^7.0.0"
@@ -506,6 +522,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
+"@babel/plugin-transform-member-expression-literals@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.2.0.tgz#fa10aa5c58a2cb6afcf2c9ffa8cb4d8b3d489a2d"
+  integrity sha512-HiU3zKkSU6scTidmnFJ0bMX8hz5ixC93b4MHMiYebmk2lUVNGOboPsqQvx5LzooihijUoLR/v7Nc1rbBtnc7FA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
 "@babel/plugin-transform-modules-amd@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.2.0.tgz#82a9bce45b95441f617a24011dc89d12da7f4ee6"
@@ -514,21 +537,21 @@
     "@babel/helper-module-transforms" "^7.1.0"
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-transform-modules-commonjs@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.2.0.tgz#c4f1933f5991d5145e9cfad1dfd848ea1727f404"
-  integrity sha512-V6y0uaUQrQPXUrmj+hgnks8va2L0zcZymeU7TtWEgdRLNkceafKXEduv7QzgQAE4lT+suwooG9dC7LFhdRAbVQ==
+"@babel/plugin-transform-modules-commonjs@^7.2.0", "@babel/plugin-transform-modules-commonjs@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.4.4.tgz#0bef4713d30f1d78c2e59b3d6db40e60192cac1e"
+  integrity sha512-4sfBOJt58sEo9a2BQXnZq+Q3ZTSAUXyK3E30o36BOGnJ+tvJ6YSxF0PG6kERvbeISgProodWuI9UVG3/FMY6iw==
   dependencies:
-    "@babel/helper-module-transforms" "^7.1.0"
+    "@babel/helper-module-transforms" "^7.4.4"
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/helper-simple-access" "^7.1.0"
 
-"@babel/plugin-transform-modules-systemjs@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.2.0.tgz#912bfe9e5ff982924c81d0937c92d24994bb9068"
-  integrity sha512-aYJwpAhoK9a+1+O625WIjvMY11wkB/ok0WClVwmeo3mCjcNRjt+/8gHWrB5i+00mUju0gWsBkQnPpdvQ7PImmQ==
+"@babel/plugin-transform-modules-systemjs@^7.2.0", "@babel/plugin-transform-modules-systemjs@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.4.4.tgz#dc83c5665b07d6c2a7b224c00ac63659ea36a405"
+  integrity sha512-MSiModfILQc3/oqnG7NrP1jHaSPryO6tA2kOMmAQApz5dayPxWiHqmq4sWH2xF5LcQK56LlbKByCd8Aah/OIkQ==
   dependencies:
-    "@babel/helper-hoist-variables" "^7.0.0"
+    "@babel/helper-hoist-variables" "^7.4.4"
     "@babel/helper-plugin-utils" "^7.0.0"
 
 "@babel/plugin-transform-modules-umd@^7.2.0":
@@ -539,17 +562,17 @@
     "@babel/helper-module-transforms" "^7.1.0"
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-transform-named-capturing-groups-regex@^7.3.0":
-  version "7.3.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.3.0.tgz#140b52985b2d6ef0cb092ef3b29502b990f9cd50"
-  integrity sha512-NxIoNVhk9ZxS+9lSoAQ/LM0V2UEvARLttEHUrRDGKFaAxOYQcrkN/nLRE+BbbicCAvZPl7wMP0X60HsHE5DtQw==
+"@babel/plugin-transform-named-capturing-groups-regex@^7.3.0", "@babel/plugin-transform-named-capturing-groups-regex@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.4.4.tgz#5611d96d987dfc4a3a81c4383bb173361037d68d"
+  integrity sha512-Ki+Y9nXBlKfhD+LXaRS7v95TtTGYRAf9Y1rTDiE75zf8YQz4GDaWRXosMfJBXxnk88mGFjWdCRIeqDbon7spYA==
   dependencies:
     regexp-tree "^0.1.0"
 
-"@babel/plugin-transform-new-target@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.0.0.tgz#ae8fbd89517fa7892d20e6564e641e8770c3aa4a"
-  integrity sha512-yin069FYjah+LbqfGeTfzIBODex/e++Yfa0rH0fpfam9uTbuEeEOx5GLGr210ggOV77mVRNoeqSYqeuaqSzVSw==
+"@babel/plugin-transform-new-target@^7.0.0", "@babel/plugin-transform-new-target@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.4.4.tgz#18d120438b0cc9ee95a47f2c72bc9768fbed60a5"
+  integrity sha512-r1z3T2DNGQwwe2vPGZMBNjioT2scgWzK9BCnDEh+46z8EEwXBq24uRzd65I7pjtugzPSj921aM15RpESgzsSuA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
@@ -561,13 +584,20 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/helper-replace-supers" "^7.1.0"
 
-"@babel/plugin-transform-parameters@^7.2.0":
-  version "7.3.3"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.3.3.tgz#3a873e07114e1a5bee17d04815662c8317f10e30"
-  integrity sha512-IrIP25VvXWu/VlBWTpsjGptpomtIkYrN/3aDp4UKm7xK6UxZY88kcJ1UwETbzHAlwN21MnNfwlar0u8y3KpiXw==
+"@babel/plugin-transform-parameters@^7.2.0", "@babel/plugin-transform-parameters@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.4.4.tgz#7556cf03f318bd2719fe4c922d2d808be5571e16"
+  integrity sha512-oMh5DUO1V63nZcu/ZVLQFqiihBGo4OpxJxR1otF50GMeCLiRx5nUdtokd+u9SuVJrvvuIh9OosRFPP4pIPnwmw==
   dependencies:
-    "@babel/helper-call-delegate" "^7.1.0"
+    "@babel/helper-call-delegate" "^7.4.4"
     "@babel/helper-get-function-arity" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-property-literals@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.2.0.tgz#03e33f653f5b25c4eb572c98b9485055b389e905"
+  integrity sha512-9q7Dbk4RhgcLp8ebduOpCbtjh7C0itoLYHXd9ueASKAG/is5PQtMR5VJGka9NKqGhYEGn5ITahd4h9QeBMylWQ==
+  dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
 "@babel/plugin-transform-react-constant-elements@7.2.0", "@babel/plugin-transform-react-constant-elements@^7.0.0":
@@ -610,12 +640,19 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-jsx" "^7.2.0"
 
-"@babel/plugin-transform-regenerator@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0.tgz#5b41686b4ed40bef874d7ed6a84bdd849c13e0c1"
-  integrity sha512-sj2qzsEx8KDVv1QuJc/dEfilkg3RRPvPYx/VnKLtItVQRWt1Wqf5eVCOLZm29CiGFfYYsA3VPjfizTCV0S0Dlw==
+"@babel/plugin-transform-regenerator@^7.0.0", "@babel/plugin-transform-regenerator@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.4.tgz#5b4da4df79391895fca9e28f99e87e22cfc02072"
+  integrity sha512-Zz3w+pX1SI0KMIiqshFZkwnVGUhDZzpX2vtPzfJBKQQq8WsP/Xy9DNdELWivxcKOCX/Pywge4SiEaPaLtoDT4g==
   dependencies:
-    regenerator-transform "^0.13.3"
+    regenerator-transform "^0.13.4"
+
+"@babel/plugin-transform-reserved-words@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.2.0.tgz#4792af87c998a49367597d07fedf02636d2e1634"
+  integrity sha512-fz43fqW8E1tAB3DKF19/vxbpib1fuyCwSPE418ge5ZxILnBhWyhtPgz8eh1RCGGJlwvksHkyxMxh0eenFi+kFw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
 
 "@babel/plugin-transform-runtime@7.2.0":
   version "7.2.0"
@@ -649,10 +686,10 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/helper-regex" "^7.0.0"
 
-"@babel/plugin-transform-template-literals@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.2.0.tgz#d87ed01b8eaac7a92473f608c97c089de2ba1e5b"
-  integrity sha512-FkPix00J9A/XWXv4VoKJBMeSkyY9x/TqIh76wzcdfl57RJJcf8CehQ08uwfhCDNtRQYtHQKBTwKZDEyjE13Lwg==
+"@babel/plugin-transform-template-literals@^7.2.0", "@babel/plugin-transform-template-literals@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.4.4.tgz#9d28fea7bbce637fb7612a0750989d8321d4bcb0"
+  integrity sha512-mQrEC4TWkhLN0z8ygIvEL9ZEToPhG5K7KDW3pzGqOfIGZ28Jb0POUkeWcoz8HnHvhFy6dwAT1j8OzqN8s804+g==
   dependencies:
     "@babel/helper-annotate-as-pure" "^7.0.0"
     "@babel/helper-plugin-utils" "^7.0.0"
@@ -665,23 +702,23 @@
     "@babel/helper-plugin-utils" "^7.0.0"
 
 "@babel/plugin-transform-typescript@^7.1.0":
-  version "7.3.2"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.3.2.tgz#59a7227163e55738842f043d9e5bd7c040447d96"
-  integrity sha512-Pvco0x0ZSCnexJnshMfaibQ5hnK8aUHSvjCQhC1JR8eeg+iBwt0AtCO7gWxJ358zZevuf9wPSO5rv+WJcbHPXQ==
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.4.4.tgz#93e9c3f2a546e6d3da1e9cc990e30791b807aa9f"
+  integrity sha512-rwDvjaMTx09WC0rXGBRlYSSkEHOKRrecY6hEr3SVIPKII8DVWXtapNAfAyMC0dovuO+zYArcAuKeu3q9DNRfzA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-typescript" "^7.2.0"
 
-"@babel/plugin-transform-unicode-regex@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.2.0.tgz#4eb8db16f972f8abb5062c161b8b115546ade08b"
-  integrity sha512-m48Y0lMhrbXEJnVUaYly29jRXbQ3ksxPrS1Tg8t+MHqzXhtBYAvI51euOBaoAlZLPHsieY9XPVMf80a5x0cPcA==
+"@babel/plugin-transform-unicode-regex@^7.2.0", "@babel/plugin-transform-unicode-regex@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.4.4.tgz#ab4634bb4f14d36728bf5978322b35587787970f"
+  integrity sha512-il+/XdNw01i93+M9J9u4T7/e/Ue/vWfNZE4IRUQjplu2Mqb/AFTDimkw2tdEdSH50wuQXZAbXSql0UphQke+vA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
-    "@babel/helper-regex" "^7.0.0"
-    regexpu-core "^4.1.3"
+    "@babel/helper-regex" "^7.4.4"
+    regexpu-core "^4.5.4"
 
-"@babel/preset-env@7.3.1", "@babel/preset-env@^7.1.6":
+"@babel/preset-env@7.3.1":
   version "7.3.1"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.3.1.tgz#389e8ca6b17ae67aaf9a2111665030be923515db"
   integrity sha512-FHKrD6Dxf30e8xgHQO0zJZpUPfVZg+Xwgz5/RdSWCbza9QLNk4Qbp40ctRoqDxml3O8RMzB1DU55SXeDG6PqHQ==
@@ -730,6 +767,60 @@
     js-levenshtein "^1.1.3"
     semver "^5.3.0"
 
+"@babel/preset-env@^7.1.6":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.4.4.tgz#b6f6825bfb27b3e1394ca3de4f926482722c1d6f"
+  integrity sha512-FU1H+ACWqZZqfw1x2G1tgtSSYSfxJLkpaUQL37CenULFARDo+h4xJoVHzRoHbK+85ViLciuI7ME4WTIhFRBBlw==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-proposal-async-generator-functions" "^7.2.0"
+    "@babel/plugin-proposal-json-strings" "^7.2.0"
+    "@babel/plugin-proposal-object-rest-spread" "^7.4.4"
+    "@babel/plugin-proposal-optional-catch-binding" "^7.2.0"
+    "@babel/plugin-proposal-unicode-property-regex" "^7.4.4"
+    "@babel/plugin-syntax-async-generators" "^7.2.0"
+    "@babel/plugin-syntax-json-strings" "^7.2.0"
+    "@babel/plugin-syntax-object-rest-spread" "^7.2.0"
+    "@babel/plugin-syntax-optional-catch-binding" "^7.2.0"
+    "@babel/plugin-transform-arrow-functions" "^7.2.0"
+    "@babel/plugin-transform-async-to-generator" "^7.4.4"
+    "@babel/plugin-transform-block-scoped-functions" "^7.2.0"
+    "@babel/plugin-transform-block-scoping" "^7.4.4"
+    "@babel/plugin-transform-classes" "^7.4.4"
+    "@babel/plugin-transform-computed-properties" "^7.2.0"
+    "@babel/plugin-transform-destructuring" "^7.4.4"
+    "@babel/plugin-transform-dotall-regex" "^7.4.4"
+    "@babel/plugin-transform-duplicate-keys" "^7.2.0"
+    "@babel/plugin-transform-exponentiation-operator" "^7.2.0"
+    "@babel/plugin-transform-for-of" "^7.4.4"
+    "@babel/plugin-transform-function-name" "^7.4.4"
+    "@babel/plugin-transform-literals" "^7.2.0"
+    "@babel/plugin-transform-member-expression-literals" "^7.2.0"
+    "@babel/plugin-transform-modules-amd" "^7.2.0"
+    "@babel/plugin-transform-modules-commonjs" "^7.4.4"
+    "@babel/plugin-transform-modules-systemjs" "^7.4.4"
+    "@babel/plugin-transform-modules-umd" "^7.2.0"
+    "@babel/plugin-transform-named-capturing-groups-regex" "^7.4.4"
+    "@babel/plugin-transform-new-target" "^7.4.4"
+    "@babel/plugin-transform-object-super" "^7.2.0"
+    "@babel/plugin-transform-parameters" "^7.4.4"
+    "@babel/plugin-transform-property-literals" "^7.2.0"
+    "@babel/plugin-transform-regenerator" "^7.4.4"
+    "@babel/plugin-transform-reserved-words" "^7.2.0"
+    "@babel/plugin-transform-shorthand-properties" "^7.2.0"
+    "@babel/plugin-transform-spread" "^7.2.0"
+    "@babel/plugin-transform-sticky-regex" "^7.2.0"
+    "@babel/plugin-transform-template-literals" "^7.4.4"
+    "@babel/plugin-transform-typeof-symbol" "^7.2.0"
+    "@babel/plugin-transform-unicode-regex" "^7.4.4"
+    "@babel/types" "^7.4.4"
+    browserslist "^4.5.2"
+    core-js-compat "^3.0.0"
+    invariant "^2.2.2"
+    js-levenshtein "^1.1.3"
+    semver "^5.5.0"
+
 "@babel/preset-react@7.0.0", "@babel/preset-react@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/preset-react/-/preset-react-7.0.0.tgz#e86b4b3d99433c7b3e9e91747e2653958bc6b3c0"
@@ -757,40 +848,40 @@
     regenerator-runtime "^0.12.0"
 
 "@babel/runtime@^7.1.2":
-  version "7.3.4"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.3.4.tgz#73d12ba819e365fcf7fd152aed56d6df97d21c83"
-  integrity sha512-IvfvnMdSaLBateu0jfsYIpZTxAc2cKEXEMiezGGN75QcBcecDUKd3PgLAncT0oOgxKy8dd8hrJKj9MfzgfZd6g==
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.4.4.tgz#dc2e34982eb236803aa27a07fea6857af1b9171d"
+  integrity sha512-w0+uT71b6Yi7i5SE0co4NioIpSYS6lLiXvCzWzGSKvpK5vdQtCbICHMj+gbAKAOtxiV6HsVh/MBdaF9EQ6faSg==
   dependencies:
-    regenerator-runtime "^0.12.0"
+    regenerator-runtime "^0.13.2"
 
-"@babel/template@^7.1.0", "@babel/template@^7.1.2", "@babel/template@^7.2.2":
-  version "7.2.2"
-  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.2.2.tgz#005b3fdf0ed96e88041330379e0da9a708eb2907"
-  integrity sha512-zRL0IMM02AUDwghf5LMSSDEz7sBCO2YnNmpg3uWTZj/v1rcG2BmQUvaGU8GhU8BvfMh1k2KIAYZ7Ji9KXPUg7g==
+"@babel/template@^7.1.0", "@babel/template@^7.2.2", "@babel/template@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.4.4.tgz#f4b88d1225689a08f5bc3a17483545be9e4ed237"
+  integrity sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==
   dependencies:
     "@babel/code-frame" "^7.0.0"
-    "@babel/parser" "^7.2.2"
-    "@babel/types" "^7.2.2"
+    "@babel/parser" "^7.4.4"
+    "@babel/types" "^7.4.4"
 
-"@babel/traverse@^7.0.0", "@babel/traverse@^7.1.0", "@babel/traverse@^7.1.5", "@babel/traverse@^7.2.2", "@babel/traverse@^7.2.3":
-  version "7.2.3"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.2.3.tgz#7ff50cefa9c7c0bd2d81231fdac122f3957748d8"
-  integrity sha512-Z31oUD/fJvEWVR0lNZtfgvVt512ForCTNKYcJBGbPb1QZfve4WGH8Wsy7+Mev33/45fhP/hwQtvgusNdcCMgSw==
+"@babel/traverse@^7.0.0", "@babel/traverse@^7.1.0", "@babel/traverse@^7.2.2", "@babel/traverse@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.4.4.tgz#0776f038f6d78361860b6823887d4f3937133fe8"
+  integrity sha512-Gw6qqkw/e6AGzlyj9KnkabJX7VcubqPtkUQVAwkc0wUMldr3A/hezNB3Rc5eIvId95iSGkGIOe5hh1kMKf951A==
   dependencies:
     "@babel/code-frame" "^7.0.0"
-    "@babel/generator" "^7.2.2"
+    "@babel/generator" "^7.4.4"
     "@babel/helper-function-name" "^7.1.0"
-    "@babel/helper-split-export-declaration" "^7.0.0"
-    "@babel/parser" "^7.2.3"
-    "@babel/types" "^7.2.2"
+    "@babel/helper-split-export-declaration" "^7.4.4"
+    "@babel/parser" "^7.4.4"
+    "@babel/types" "^7.4.4"
     debug "^4.1.0"
     globals "^11.1.0"
-    lodash "^4.17.10"
+    lodash "^4.17.11"
 
-"@babel/types@^7.0.0", "@babel/types@^7.1.6", "@babel/types@^7.2.0", "@babel/types@^7.2.2", "@babel/types@^7.3.0", "@babel/types@^7.3.3":
-  version "7.3.3"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.3.3.tgz#6c44d1cdac2a7625b624216657d5bc6c107ab436"
-  integrity sha512-2tACZ80Wg09UnPg5uGAOUvvInaqLk3l/IAhQzlxLQOIXacr6bMsra5SH6AWw/hIDRCSbCdHP2KzSOD+cT7TzMQ==
+"@babel/types@^7.0.0", "@babel/types@^7.2.0", "@babel/types@^7.2.2", "@babel/types@^7.3.0", "@babel/types@^7.4.0", "@babel/types@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.4.4.tgz#8db9e9a629bb7c29370009b4b779ed93fe57d5f0"
+  integrity sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==
   dependencies:
     esutils "^2.0.2"
     lodash "^4.17.11"
@@ -822,96 +913,96 @@
     exenv "^1.2.2"
     prop-types "^15.6.2"
 
-"@svgr/babel-plugin-add-jsx-attribute@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-4.0.0.tgz#5acf239cd2747b1a36ec7e708de05d914cb9b948"
-  integrity sha512-PDvHV2WhSGCSExp+eIMEKxYd1Q0SBvXLb4gAOXbdh0dswHFFgXWzxGjCmx5aln4qGrhkuN81khzYzR/44DYaMA==
+"@svgr/babel-plugin-add-jsx-attribute@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-4.2.0.tgz#dadcb6218503532d6884b210e7f3c502caaa44b1"
+  integrity sha512-j7KnilGyZzYr/jhcrSYS3FGWMZVaqyCG0vzMCwzvei0coIkczuYMcniK07nI0aHJINciujjH11T72ICW5eL5Ig==
 
-"@svgr/babel-plugin-remove-jsx-attribute@^4.0.3":
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/@svgr/babel-plugin-remove-jsx-attribute/-/babel-plugin-remove-jsx-attribute-4.0.3.tgz#32564b5c4d761b51e34492b6a4894196c0f75803"
-  integrity sha512-fpG7AzzJxz1tc8ITYS1jCAt1cq4ydK2R+sx//BMTJgvOjfk91M5GiqFolP8aYTzLcum92IGNAVFS3zEcucOQEA==
+"@svgr/babel-plugin-remove-jsx-attribute@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@svgr/babel-plugin-remove-jsx-attribute/-/babel-plugin-remove-jsx-attribute-4.2.0.tgz#297550b9a8c0c7337bea12bdfc8a80bb66f85abc"
+  integrity sha512-3XHLtJ+HbRCH4n28S7y/yZoEQnRpl0tvTZQsHqvaeNXPra+6vE5tbRliH3ox1yZYPCxrlqaJT/Mg+75GpDKlvQ==
 
-"@svgr/babel-plugin-remove-jsx-empty-expression@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@svgr/babel-plugin-remove-jsx-empty-expression/-/babel-plugin-remove-jsx-empty-expression-4.0.0.tgz#0b59338c00671cf8137eb823bd84a3efac686502"
-  integrity sha512-nBGVl6LzXTdk1c6w3rMWcjq3mYGz+syWc5b3CdqAiEeY/nswYDoW/cnGUKKC8ofD6/LaG+G/IUnfv3jKoHz43A==
+"@svgr/babel-plugin-remove-jsx-empty-expression@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@svgr/babel-plugin-remove-jsx-empty-expression/-/babel-plugin-remove-jsx-empty-expression-4.2.0.tgz#c196302f3e68eab6a05e98af9ca8570bc13131c7"
+  integrity sha512-yTr2iLdf6oEuUE9MsRdvt0NmdpMBAkgK8Bjhl6epb+eQWk6abBaX3d65UZ3E3FWaOwePyUgNyNCMVG61gGCQ7w==
 
-"@svgr/babel-plugin-replace-jsx-attribute-value@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@svgr/babel-plugin-replace-jsx-attribute-value/-/babel-plugin-replace-jsx-attribute-value-4.0.0.tgz#91785643540c2300f3d89e515b37af9b5ce4e695"
-  integrity sha512-ejQqpTfORy6TT5w1x/2IQkscgfbtNFjitcFDu63GRz7qfhVTYhMdiJvJ1+Aw9hmv9bO4tXThGQDr1IF5lIvgew==
+"@svgr/babel-plugin-replace-jsx-attribute-value@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@svgr/babel-plugin-replace-jsx-attribute-value/-/babel-plugin-replace-jsx-attribute-value-4.2.0.tgz#310ec0775de808a6a2e4fd4268c245fd734c1165"
+  integrity sha512-U9m870Kqm0ko8beHawRXLGLvSi/ZMrl89gJ5BNcT452fAjtF2p4uRzXkdzvGJJJYBgx7BmqlDjBN/eCp5AAX2w==
 
-"@svgr/babel-plugin-svg-dynamic-title@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@svgr/babel-plugin-svg-dynamic-title/-/babel-plugin-svg-dynamic-title-4.0.0.tgz#eb8d50b80ba0a26f9b27c7268e2a803d90f1bc9e"
-  integrity sha512-OE6GT9WRKWqd0Dk6NJ5TYXTF5OxAyn74+c/D+gTLbCXnK2A0luEXuwMbe5zR5Px4A/jow2OeEBboTENl4vtuQg==
+"@svgr/babel-plugin-svg-dynamic-title@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@svgr/babel-plugin-svg-dynamic-title/-/babel-plugin-svg-dynamic-title-4.2.0.tgz#43f0f689a5347a894160eb51b39a109889a4df20"
+  integrity sha512-gH2qItapwCUp6CCqbxvzBbc4dh4OyxdYKsW3EOkYexr0XUmQL0ScbdNh6DexkZ01T+sdClniIbnCObsXcnx3sQ==
 
-"@svgr/babel-plugin-svg-em-dimensions@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@svgr/babel-plugin-svg-em-dimensions/-/babel-plugin-svg-em-dimensions-4.0.0.tgz#0de3972c46ff1960bed765646037a3a7f9e1da3d"
-  integrity sha512-QeDRGHXfjYEBTXxV0TsjWmepsL9Up5BOOlMFD557x2JrSiVGUn2myNxHIrHiVW0+nnWnaDcrkjg/jUvbJ5nKCg==
+"@svgr/babel-plugin-svg-em-dimensions@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@svgr/babel-plugin-svg-em-dimensions/-/babel-plugin-svg-em-dimensions-4.2.0.tgz#9a94791c9a288108d20a9d2cc64cac820f141391"
+  integrity sha512-C0Uy+BHolCHGOZ8Dnr1zXy/KgpBOkEUYY9kI/HseHVPeMbluaX3CijJr7D4C5uR8zrc1T64nnq/k63ydQuGt4w==
 
-"@svgr/babel-plugin-transform-react-native-svg@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@svgr/babel-plugin-transform-react-native-svg/-/babel-plugin-transform-react-native-svg-4.0.0.tgz#5e8ecc2a9870ae05fb1e553b1fe9c6b5853a1c66"
-  integrity sha512-c6eE6ovs14k6dmHKoy26h7iRFhjWNnwYVrDWIPfouVm/gcLIeMw/ME4i91O5LEfaDHs6kTRCcVpbAVbNULZOtw==
+"@svgr/babel-plugin-transform-react-native-svg@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@svgr/babel-plugin-transform-react-native-svg/-/babel-plugin-transform-react-native-svg-4.2.0.tgz#151487322843359a1ca86b21a3815fd21a88b717"
+  integrity sha512-7YvynOpZDpCOUoIVlaaOUU87J4Z6RdD6spYN4eUb5tfPoKGSF9OG2NuhgYnq4jSkAxcpMaXWPf1cePkzmqTPNw==
 
-"@svgr/babel-plugin-transform-svg-component@^4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@svgr/babel-plugin-transform-svg-component/-/babel-plugin-transform-svg-component-4.1.0.tgz#257159e28a21ac20988b1eaa5f59d4724f37fdaa"
-  integrity sha512-uulxdx2p3nrM2BkrtADQHK8IhEzCxdUILfC/ddvFC8tlFWuKiA3ych8C6q0ulyQHq34/3hzz+3rmUbhWF9redg==
+"@svgr/babel-plugin-transform-svg-component@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@svgr/babel-plugin-transform-svg-component/-/babel-plugin-transform-svg-component-4.2.0.tgz#5f1e2f886b2c85c67e76da42f0f6be1b1767b697"
+  integrity sha512-hYfYuZhQPCBVotABsXKSCfel2slf/yvJY8heTVX1PCTaq/IgASq1IyxPPKJ0chWREEKewIU/JMSsIGBtK1KKxw==
 
-"@svgr/babel-preset@^4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@svgr/babel-preset/-/babel-preset-4.1.0.tgz#f6fa8ad90064b85dd7a3566a70b7006e789e8385"
-  integrity sha512-Nat5aJ3VO3LE8KfMyIbd3sGWnaWPiFCeWIdEV+lalga0To/tpmzsnPDdnrR9fNYhvSSLJbwhU/lrLYt9wXY0ZQ==
+"@svgr/babel-preset@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@svgr/babel-preset/-/babel-preset-4.2.0.tgz#c9fc236445a02a8cd4e750085e51c181de00d6c5"
+  integrity sha512-iLetHpRCQXfK47voAs5/uxd736cCyocEdorisjAveZo8ShxJ/ivSZgstBmucI1c8HyMF5tOrilJLoFbhpkPiKw==
   dependencies:
-    "@svgr/babel-plugin-add-jsx-attribute" "^4.0.0"
-    "@svgr/babel-plugin-remove-jsx-attribute" "^4.0.3"
-    "@svgr/babel-plugin-remove-jsx-empty-expression" "^4.0.0"
-    "@svgr/babel-plugin-replace-jsx-attribute-value" "^4.0.0"
-    "@svgr/babel-plugin-svg-dynamic-title" "^4.0.0"
-    "@svgr/babel-plugin-svg-em-dimensions" "^4.0.0"
-    "@svgr/babel-plugin-transform-react-native-svg" "^4.0.0"
-    "@svgr/babel-plugin-transform-svg-component" "^4.1.0"
+    "@svgr/babel-plugin-add-jsx-attribute" "^4.2.0"
+    "@svgr/babel-plugin-remove-jsx-attribute" "^4.2.0"
+    "@svgr/babel-plugin-remove-jsx-empty-expression" "^4.2.0"
+    "@svgr/babel-plugin-replace-jsx-attribute-value" "^4.2.0"
+    "@svgr/babel-plugin-svg-dynamic-title" "^4.2.0"
+    "@svgr/babel-plugin-svg-em-dimensions" "^4.2.0"
+    "@svgr/babel-plugin-transform-react-native-svg" "^4.2.0"
+    "@svgr/babel-plugin-transform-svg-component" "^4.2.0"
 
 "@svgr/core@^4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@svgr/core/-/core-4.1.0.tgz#4f8ad24fb4ab25c787c12a6bbb511c6430558f83"
-  integrity sha512-ahv3lvOKuUAcs0KbQ4Jr5fT5pGHhye4ew8jZVS4lw8IQdWrbG/o3rkpgxCPREBk7PShmEoGQpteeXVwp2yExuQ==
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@svgr/core/-/core-4.2.0.tgz#f32ef8b9d05312aaa775896ec30ae46a6521e248"
+  integrity sha512-nvzXaf2VavqjMCTTfsZfjL4o9035KedALkMzk82qOlHOwBb8JT+9+zYDgBl0oOunbVF94WTLnvGunEg0csNP3Q==
   dependencies:
-    "@svgr/plugin-jsx" "^4.1.0"
-    camelcase "^5.0.0"
-    cosmiconfig "^5.0.7"
+    "@svgr/plugin-jsx" "^4.2.0"
+    camelcase "^5.3.1"
+    cosmiconfig "^5.2.0"
 
-"@svgr/hast-util-to-babel-ast@^4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@svgr/hast-util-to-babel-ast/-/hast-util-to-babel-ast-4.1.0.tgz#a1eb0f47059769896f759f47995b636fce5d9fa4"
-  integrity sha512-tdkEZHmigYYiVhIEzycAMKN5aUSpddUnjr6v7bPwaNTFuSyqGUrpCg1JlIGi7PUaaJVHbn6whGQMGUpKOwT5nw==
+"@svgr/hast-util-to-babel-ast@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@svgr/hast-util-to-babel-ast/-/hast-util-to-babel-ast-4.2.0.tgz#dd743435a5f3a8e84a1da067f27b5fae3d7b6b63"
+  integrity sha512-IvAeb7gqrGB5TH9EGyBsPrMRH/QCzIuAkLySKvH2TLfLb2uqk98qtJamordRQTpHH3e6TORfBXoTo7L7Opo/Ow==
   dependencies:
-    "@babel/types" "^7.1.6"
+    "@babel/types" "^7.4.0"
 
-"@svgr/plugin-jsx@^4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@svgr/plugin-jsx/-/plugin-jsx-4.1.0.tgz#4045e9cc0589374a6c182a1217c80e6734b5cbec"
-  integrity sha512-xwu+9TGziuN7cu7p+vhCw2EJIfv8iDNMzn2dR0C7fBYc8q+SRtYTcg4Uyn8ZWh6DM+IZOlVrS02VEMT0FQzXSA==
+"@svgr/plugin-jsx@^4.1.0", "@svgr/plugin-jsx@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@svgr/plugin-jsx/-/plugin-jsx-4.2.0.tgz#15a91562c9b5f90640ea0bdcb2ad59d692ee7ae9"
+  integrity sha512-AM1YokmZITgveY9bulLVquqNmwiFo2Px2HL+IlnTCR01YvWDfRL5QKdnF7VjRaS5MNP938mmqvL0/8oz3zQMkg==
   dependencies:
-    "@babel/core" "^7.1.6"
-    "@svgr/babel-preset" "^4.1.0"
-    "@svgr/hast-util-to-babel-ast" "^4.1.0"
+    "@babel/core" "^7.4.3"
+    "@svgr/babel-preset" "^4.2.0"
+    "@svgr/hast-util-to-babel-ast" "^4.2.0"
     rehype-parse "^6.0.0"
-    unified "^7.0.2"
-    vfile "^3.0.1"
+    unified "^7.1.0"
+    vfile "^4.0.0"
 
 "@svgr/plugin-svgo@^4.0.3":
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/@svgr/plugin-svgo/-/plugin-svgo-4.0.3.tgz#a07ea0a736c26fa3a5440fe8e222e2e887764cab"
-  integrity sha512-MgL1CrlxvNe+1tQjPUc2bIJtsdJOIE5arbHlPgW+XVWGjMZTUcyNNP8R7/IjM2Iyrc98UJY+WYiiWHrinnY9ZQ==
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@svgr/plugin-svgo/-/plugin-svgo-4.2.0.tgz#2a594a2d3312955e75fd87dc77ae51f377c809f3"
+  integrity sha512-zUEKgkT172YzHh3mb2B2q92xCnOAMVjRx+o0waZ1U50XqKLrVQ/8dDqTAtnmapdLsGurv8PSwenjLCUpj6hcvw==
   dependencies:
-    cosmiconfig "^5.0.7"
+    cosmiconfig "^5.2.0"
     merge-deep "^3.0.2"
-    svgo "^1.1.1"
+    svgo "^1.2.1"
 
 "@svgr/webpack@4.1.0":
   version "4.1.0"
@@ -928,21 +1019,21 @@
     loader-utils "^1.1.0"
 
 "@types/node@*":
-  version "11.9.5"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-11.9.5.tgz#011eece9d3f839a806b63973e228f85967b79ed3"
-  integrity sha512-vVjM0SVzgaOUpflq4GYBvCpozes8OgIIS5gVXVka+OfK3hvnkC1i93U8WiY2OtNE4XUWyyy/86Kf6e0IHTQw1Q==
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.0.0.tgz#d11813b9c0ff8aaca29f04cbc12817f4c7d656e5"
+  integrity sha512-Jrb/x3HT4PTJp6a4avhmJCDEVrPdqLfl3e8GGMbpkGGdwAV5UGlIs4vVEfsHHfylZVOKZWpOqmqFH8CbfOZ6kg==
 
 "@types/q@^1.5.1":
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.1.tgz#48fd98c1561fe718b61733daed46ff115b496e18"
-  integrity sha512-eqz8c/0kwNi/OEHQfvIuJVLTst3in0e7uTKeuY+WL/zfKn0xVujOTp42bS/vUUokhK5P2BppLd9JXMOMHcgbjA==
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.2.tgz#690a1475b84f2a884fd07cd797c00f5f31356ea8"
+  integrity sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==
 
 "@types/tapable@1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.2.tgz#e13182e1b69871a422d7863e11a4a6f5b814a4bd"
   integrity sha512-42zEJkBpNfMEAvWR5WlwtTH22oDzcMjFsL9gDGExwF8X8WvAiw7Vwop7hPw03QT8TKfec83LwbHj6SvpqM4ELQ==
 
-"@types/unist@*", "@types/unist@^2.0.0":
+"@types/unist@*", "@types/unist@^2.0.0", "@types/unist@^2.0.2":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
   integrity sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==
@@ -1128,12 +1219,12 @@ abbrev@1:
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
 accepts@~1.3.4, accepts@~1.3.5:
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.5.tgz#eb777df6011723a3b14e8a72c0805c8e86746bd2"
-  integrity sha1-63d99gEXI6OxTopywIBcjoZ0a9I=
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.7.tgz#531bc726517a3b2b41f850021c6cc15eaab507cd"
+  integrity sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==
   dependencies:
-    mime-types "~2.1.18"
-    negotiator "0.6.1"
+    mime-types "~2.1.24"
+    negotiator "0.6.2"
 
 acorn-dynamic-import@^3.0.0:
   version "3.0.0"
@@ -1143,9 +1234,9 @@ acorn-dynamic-import@^3.0.0:
     acorn "^5.0.0"
 
 acorn-globals@^4.1.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-4.3.0.tgz#e3b6f8da3c1552a95ae627571f7dd6923bb54103"
-  integrity sha512-hMtHj3s5RnuhvHPowpBYvJVj3rAar82JiDQHvGs1zO0l10ocX/xEdBShNHTJaboucJUsScghp74pH3s7EnHHQw==
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-4.3.2.tgz#4e2c2313a597fd589720395f6354b41cd5ec8006"
+  integrity sha512-BbzvZhVtZP+Bs1J1HcwrQe8ycfO0wStkSGxuul3He3GkHOIZ6eTqOkPuw9IP1X3+IkOo4wiJmwkobzXYz4wewQ==
   dependencies:
     acorn "^6.0.1"
     acorn-walk "^6.0.1"
@@ -1166,14 +1257,19 @@ acorn@^5.0.0, acorn@^5.5.3, acorn@^5.6.2:
   integrity sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==
 
 acorn@^6.0.1, acorn@^6.0.7:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.1.0.tgz#b0a3be31752c97a0f7013c5f4903b71a05db6818"
-  integrity sha512-MW/FjM+IvU9CgBzjO3UIPCE2pyEwUsoFl+VGdczOPEdxfGFjuKny/gN54mOuX7Qxmb9Rg9MCn2oKiSUeW+pjrw==
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.1.1.tgz#7d25ae05bb8ad1f9b699108e1094ecd7884adc1f"
+  integrity sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==
 
-address@1.0.3, address@^1.0.1:
+address@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/address/-/address-1.0.3.tgz#b5f50631f8d6cec8bd20c963963afb55e06cbce9"
   integrity sha512-z55ocwKBRLryBs394Sm3ushTtBeg6VAeuku7utSoSnsJKvKcnXFIyC6vh27n3rXyxSgkJBBCAvyOn7gSUcTYjg==
+
+address@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/address/-/address-1.1.0.tgz#ef8e047847fcd2c5b6f50c16965f924fd99fe709"
+  integrity sha512-4diPfzWbLEIElVG4AnqP+00SULlPzNuyJFNnmMrLgyaxG6tZXJ1sn7mjBu4fHrJE+Yp/jgylOweJn2xsLMFggQ==
 
 ajv-errors@^1.0.0:
   version "1.0.1"
@@ -1186,9 +1282,9 @@ ajv-keywords@^3.1.0:
   integrity sha512-aUjdRFISbuFOl0EIZc+9e4FfZp0bDZgAdOOf30bJmw8VM9v84SHyVyxDfbWxpGYbdZD/9XoKxfHVNmxPkhwyGw==
 
 ajv@^6.1.0, ajv@^6.5.3, ajv@^6.5.5, ajv@^6.9.1:
-  version "6.9.2"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.9.2.tgz#4927adb83e7f48e5a32b45729744c71ec39c9c7b"
-  integrity sha512-4UFy0/LgDo7Oa/+wOAlj44tp9K78u38E5/359eSrqEp1Z5PdVfimCcs7SluXMP755RUQu6d2b4AvF0R1C9RZjg==
+  version "6.10.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.10.0.tgz#90d0d54439da587cd7e843bfb7045f50bd22bdf1"
+  integrity sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==
   dependencies:
     fast-deep-equal "^2.0.1"
     fast-json-stable-stringify "^2.0.0"
@@ -1201,9 +1297,9 @@ alphanum-sort@^1.0.0:
   integrity sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=
 
 ansi-colors@^3.0.0:
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-3.2.3.tgz#57d35b8686e851e2cc04c403f1c00203976a1813"
-  integrity sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-3.2.4.tgz#e3a3da4bfbae6c86a9c285625de124a234026fbf"
+  integrity sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==
 
 ansi-escapes@^3.0.0, ansi-escapes@^3.2.0:
   version "3.2.0"
@@ -1225,10 +1321,10 @@ ansi-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
   integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
 
-ansi-regex@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.0.0.tgz#70de791edf021404c3fd615aa89118ae0432e5a9"
-  integrity sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==
+ansi-regex@^4.0.0, ansi-regex@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
+  integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
 
 ansi-styles@^2.2.1:
   version "2.2.1"
@@ -1399,10 +1495,11 @@ assert-plus@1.0.0, assert-plus@^1.0.0:
   integrity sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=
 
 assert@^1.1.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/assert/-/assert-1.4.1.tgz#99912d591836b5a6f5b345c0f07eefc08fc65d91"
-  integrity sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/assert/-/assert-1.5.0.tgz#55c109aaf6e0aefdb3dc4b71240c70bf574b18eb"
+  integrity sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==
   dependencies:
+    object-assign "^4.1.1"
     util "0.10.3"
 
 assign-symbols@^1.0.0:
@@ -1421,9 +1518,9 @@ astral-regex@^1.0.0:
   integrity sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==
 
 async-each@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
-  integrity sha1-GdOGodntxufByF04iu28xW0zYC0=
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.3.tgz#b727dbf87d7651602f06f4d4ac387f47d91b0cbf"
+  integrity sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==
 
 async-limiter@~1.0.0:
   version "1.0.0"
@@ -1435,7 +1532,7 @@ async@^1.5.2:
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
   integrity sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=
 
-async@^2.1.4, async@^2.5.0:
+async@^2.1.4:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.2.tgz#18330ea7e6e313887f5d2f2a904bac6fe4dd5381"
   integrity sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==
@@ -1453,12 +1550,12 @@ atob@^2.1.1:
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
 autoprefixer@^9.4.2:
-  version "9.4.8"
-  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-9.4.8.tgz#575dcdfd984228c7bccbc08c5fe53f0ea6915593"
-  integrity sha512-DIhd0KMi9Nql3oJkJ2HCeOVihrXFPtWXc6ckwaUNwliDOt9OGr0fk8vV8jCLWXnZc1EXvQ2uLUzGpcPxFAQHEQ==
+  version "9.5.1"
+  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-9.5.1.tgz#243b1267b67e7e947f28919d786b50d3bb0fb357"
+  integrity sha512-KJSzkStUl3wP0D5sdMlP82Q52JLy5+atf2MHAre48+ckWkXgixmfHyWmA77wFDy6jTHU6mIgXv6hAQ2mf1PjJQ==
   dependencies:
-    browserslist "^4.4.1"
-    caniuse-lite "^1.0.30000938"
+    browserslist "^4.5.4"
+    caniuse-lite "^1.0.30000957"
     normalize-range "^0.1.2"
     num2fraction "^1.2.2"
     postcss "^7.0.14"
@@ -1625,9 +1722,9 @@ babel-plugin-macros@2.5.0:
     resolve "^1.8.1"
 
 babel-plugin-named-asset-import@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.1.tgz#5ec13ec446d0a1e5bb6c57a1f94c9cdedb0c50d6"
-  integrity sha512-vzZlo+yEB5YHqI6CRRTDojeT43J3Wf3C/MVkZW5UlbSeIIVUYRKtxaFT2L/VTv9mbIyatCW39+9g/SZolvwRUQ==
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.2.tgz#20978ed446b8e1bf4a2f42d0a94c0ece85f75f4f"
+  integrity sha512-CxwvxrZ9OirpXQ201Ec57OmGhmI8/ui/GwTDy0hSp6CmRvgRC0pSair6Z04Ck+JStA0sMPZzSJ3uE4n17EXpPQ==
 
 babel-plugin-syntax-object-rest-spread@^6.13.0, babel-plugin-syntax-object-rest-spread@^6.8.0:
   version "6.13.0"
@@ -1655,10 +1752,10 @@ babel-preset-jest@^23.2.0:
     babel-plugin-jest-hoist "^23.2.0"
     babel-plugin-syntax-object-rest-spread "^6.13.0"
 
-babel-preset-react-app@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/babel-preset-react-app/-/babel-preset-react-app-7.0.1.tgz#8dd7fef73fba124a6e140d245185ca657a943313"
-  integrity sha512-cic2V+GftWwt82XNMKGxvkFAVvuaBISy0/mzNLLPlALXXJxUvxJgVy2DI8HVk311oewJsmBiu/unE4wINUCvkg==
+babel-preset-react-app@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/babel-preset-react-app/-/babel-preset-react-app-7.0.2.tgz#d01ae973edc93b9f1015cb0236dd55889a584308"
+  integrity sha512-mwCk/u2wuiO8qQqblN5PlDa44taY0acq7hw6W+a70W522P7a9mIcdggL1fe5/LgAT7tqCq46q9wwhqaMoYKslQ==
   dependencies:
     "@babel/core" "7.2.2"
     "@babel/plugin-proposal-class-properties" "7.3.0"
@@ -1743,9 +1840,9 @@ babylon@^6.18.0:
   integrity sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==
 
 bail@^1.0.0:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/bail/-/bail-1.0.3.tgz#63cfb9ddbac829b02a3128cd53224be78e6c21a3"
-  integrity sha512-1X8CnjFVQ+a+KW36uBNMTU5s8+v5FzeqrP7hTG5aTb4aPreSbZJlhwPon9VKMuEVgV++JM+SQrALY3kr7eswdg==
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/bail/-/bail-1.0.4.tgz#7181b66d508aa3055d3f6c13f0a0c720641dde9b"
+  integrity sha512-S8vuDB4w6YpRhICUDET3guPlQpaJl7od94tpZ0Fvnyp+MKW/HyDTcRDck+29C9g+d/qQHnddRH3+94kZdrW0Ww==
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -1798,14 +1895,14 @@ big.js@^5.2.2:
   integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
 
 binary-extensions@^1.0.0:
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.13.0.tgz#9523e001306a32444b907423f1de2164222f6ab1"
-  integrity sha512-EgmjVLMn22z7eGGv3kcnHwSnJXmFHjISTY9E/S5lIcTD3Oxw05QTcBLNkJFzcb3cNueUdF/IN4U+d78V0zO8Hw==
+  version "1.13.1"
+  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.13.1.tgz#598afe54755b2868a5330d2aff9d4ebb53209b65"
+  integrity sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==
 
 bluebird@^3.5.1, bluebird@^3.5.3:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.3.tgz#7d01c6f9616c9a51ab0f8c549a79dfe6ec33efa7"
-  integrity sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw==
+  version "3.5.4"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.4.tgz#d6cc661595de30d5b3af5fcedd3c0b3ef6ec5714"
+  integrity sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw==
 
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
   version "4.11.8"
@@ -1963,14 +2060,14 @@ browserslist@4.4.1:
     electron-to-chromium "^1.3.103"
     node-releases "^1.1.3"
 
-browserslist@^4.0.0, browserslist@^4.3.4, browserslist@^4.3.5, browserslist@^4.4.1:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.4.2.tgz#6ea8a74d6464bb0bd549105f659b41197d8f0ba2"
-  integrity sha512-ISS/AIAiHERJ3d45Fz0AVYKkgcy+F/eJHzKEvv1j0wwKGKD9T3BrwKr/5g45L+Y4XIK5PlTqefHciRFcfE1Jxg==
+browserslist@^4.0.0, browserslist@^4.3.4, browserslist@^4.3.5, browserslist@^4.5.2, browserslist@^4.5.4:
+  version "4.5.6"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.5.6.tgz#ea42e8581ca2513fa7f371d4dd66da763938163d"
+  integrity sha512-o/hPOtbU9oX507lIqon+UvPYqpx3mHc8cV3QemSBTXwkG8gSQSK6UKvXcE/DcleU3+A59XTUHyCvZ5qGy8xVAg==
   dependencies:
-    caniuse-lite "^1.0.30000939"
-    electron-to-chromium "^1.3.113"
-    node-releases "^1.1.8"
+    caniuse-lite "^1.0.30000963"
+    electron-to-chromium "^1.3.127"
+    node-releases "^1.1.17"
 
 bser@^2.0.0:
   version "2.0.0"
@@ -2073,9 +2170,9 @@ callsites@^2.0.0:
   integrity sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=
 
 callsites@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.0.0.tgz#fb7eb569b72ad7a45812f93fd9430a3e410b3dd3"
-  integrity sha512-tWnkwu9YEq2uzlBDI4RcLn8jrFvF9AOi8PxDNU3hZZjJcjkcRAq3vCI+vZcg1SuxISDYe86k9VZFwAxDiJGoAw==
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
+  integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
 camel-case@3.0.x:
   version "3.0.0"
@@ -2090,10 +2187,10 @@ camelcase@^4.1.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
   integrity sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=
 
-camelcase@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.0.0.tgz#03295527d58bd3cd4aa75363f35b2e8d97be2f42"
-  integrity sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==
+camelcase@^5.3.1:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
+  integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
 caniuse-api@^3.0.0:
   version "3.0.0"
@@ -2105,10 +2202,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000918, caniuse-lite@^1.0.30000929, caniuse-lite@^1.0.30000938, caniuse-lite@^1.0.30000939:
-  version "1.0.30000939"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000939.tgz#b9ab7ac9e861bf78840b80c5dfbc471a5cd7e679"
-  integrity sha512-oXB23ImDJOgQpGjRv1tCtzAvJr4/OvrHi5SO2vUgB0g0xpdZZoA/BxfImiWfdwoYdUTtQrPsXsvYU/dmCSM8gg==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000918, caniuse-lite@^1.0.30000929, caniuse-lite@^1.0.30000957, caniuse-lite@^1.0.30000963:
+  version "1.0.30000967"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000967.tgz#a5039577806fccee80a04aaafb2c0890b1ee2f73"
+  integrity sha512-rUBIbap+VJfxTzrM4akJ00lkvVb5/n5v3EGXfWzSH5zT8aJmGzjA8HWhJ4U6kCpzxozUSnB+yvAYDRPY6mRpgQ==
 
 capture-exit@^1.2.0:
   version "1.2.0"
@@ -2128,9 +2225,9 @@ caseless@~0.12.0:
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
 ccount@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/ccount/-/ccount-1.0.3.tgz#f1cec43f332e2ea5a569fd46f9f5bde4e6102aff"
-  integrity sha512-Jt9tIBkRc9POUof7QA/VwWd+58fKkEEfI+/t1/eOlxKM7ZhrczNzMFefge7Ai+39y1pR/pP6cI19guHy3FSLmw==
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/ccount/-/ccount-1.0.4.tgz#9cf2de494ca84060a2a8d2854edd6dfb0445f386"
+  integrity sha512-fpZ81yYfzentuieinmGnphk0pLkOTMm6MZdVqwd77ROvhko6iujLNGrHH5E7utq3ygWklwfmwuG+A7P+NpqT6w==
 
 chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
@@ -2163,9 +2260,9 @@ check-types@^7.3.0:
   integrity sha512-YbulWHdfP99UfZ73NcUDlNJhEIDgm9Doq9GhpyXbF+7Aegi3CVV7qqMCKTTqJxlvEvnQBp9IA+dxsGN6xK/nSg==
 
 chokidar@^2.0.0, chokidar@^2.0.2, chokidar@^2.0.4:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.2.tgz#9c23ea40b01638439e0513864d362aeacc5ad058"
-  integrity sha512-IwXUx0FXc5ibYmPC2XeEj5mpXoV66sR+t3jqu2NS2GYwCktt3KF1/Qqjws/NkegajBA4RbZ5+DDwlOiJsxDHEg==
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.5.tgz#0ae8434d962281a5f56c72869e79cb6d9d86ad4d"
+  integrity sha512-i0TprVWp+Kj4WRPtInjexJ8Q+BqTE909VpH8xVhXrJkoc5QC8VO9TryGOqTr+2hljzc1sC62t22h5tZePodM/A==
   dependencies:
     anymatch "^2.0.0"
     async-each "^1.0.1"
@@ -2177,7 +2274,7 @@ chokidar@^2.0.0, chokidar@^2.0.2, chokidar@^2.0.4:
     normalize-path "^3.0.0"
     path-is-absolute "^1.0.0"
     readdirp "^2.2.1"
-    upath "^1.1.0"
+    upath "^1.1.1"
   optionalDependencies:
     fsevents "^1.2.7"
 
@@ -2280,7 +2377,7 @@ co@^4.6.0:
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
   integrity sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=
 
-coa@~2.0.1:
+coa@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/coa/-/coa-2.0.2.tgz#43f6c21151b4ef2bf57187db0d73de229e3e7ec3"
   integrity sha512-q5/jG+YQnSy4nRTV4F7lPepBJZ8qBNJJDBuJdoejDyLXgmL7IEo+Le2JDZudFTFt7mrCqIRaSjws4ygRCTCAXA==
@@ -2328,38 +2425,36 @@ color-string@^1.5.2:
     simple-swizzle "^0.2.2"
 
 color@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/color/-/color-3.1.0.tgz#d8e9fb096732875774c84bf922815df0308d0ffc"
-  integrity sha512-CwyopLkuRYO5ei2EpzpIh6LqJMt6Mt+jZhO5VI5f/wJLZriXQE32/SSqzmrh+QB+AZT81Cj8yv+7zwToW8ahZg==
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/color/-/color-3.1.1.tgz#7abf5c0d38e89378284e873c207ae2172dcc8a61"
+  integrity sha512-PvUltIXRjehRKPSy89VnDWFKY58xyhTLyxIg21vwQBI6qLwZNPmC8k3C1uytIgFKEpOIzN4y32iPm8231zFHIg==
   dependencies:
     color-convert "^1.9.1"
     color-string "^1.5.2"
 
-colors@~1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
-  integrity sha1-FopHAXVran9RoSzgyXv6KMCE7WM=
-
 combined-stream@^1.0.6, combined-stream@~1.0.6:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.7.tgz#2d1d24317afb8abe95d6d2c0b07b57813539d828"
-  integrity sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
 
 comma-separated-tokens@^1.0.0:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/comma-separated-tokens/-/comma-separated-tokens-1.0.5.tgz#b13793131d9ea2d2431cf5b507ddec258f0ce0db"
-  integrity sha512-Cg90/fcK93n0ecgYTAz1jaA3zvnQ0ExlmKY1rdbyHqAx6BHxwoJc+J7HDu0iuQ7ixEs1qaa+WyQ6oeuBpYP1iA==
-  dependencies:
-    trim "0.0.1"
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/comma-separated-tokens/-/comma-separated-tokens-1.0.6.tgz#3cd3d8adc725ab473843db338bcdfd4a7bb087bf"
+  integrity sha512-f20oA7jsrrmERTS70r3tmRSxR8IJV2MTN7qe6hzgX+3ARfXrdMJFvGWvWQK0xpcBurg9j9eO2MiqzZ8Y+/UPCA==
 
-commander@2.17.x, commander@~2.17.1:
+commander@2.17.x:
   version "2.17.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
   integrity sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==
 
-commander@^2.11.0:
+commander@^2.11.0, commander@^2.19.0, commander@~2.20.0:
+  version "2.20.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
+  integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
+
+commander@~2.19.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
   integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
@@ -2375,27 +2470,27 @@ commondir@^1.0.1:
   integrity sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=
 
 component-emitter@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
-  integrity sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
+  integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
 
-compressible@~2.0.14:
-  version "2.0.16"
-  resolved "https://registry.yarnpkg.com/compressible/-/compressible-2.0.16.tgz#a49bf9858f3821b64ce1be0296afc7380466a77f"
-  integrity sha512-JQfEOdnI7dASwCuSPWIeVYwc/zMsu/+tRhoUvEfXz2gxOA2DNjmG5vhtFdBlhWPPGo+RdT9S3tgc/uH5qgDiiA==
+compressible@~2.0.16:
+  version "2.0.17"
+  resolved "https://registry.yarnpkg.com/compressible/-/compressible-2.0.17.tgz#6e8c108a16ad58384a977f3a482ca20bff2f38c1"
+  integrity sha512-BGHeLCK1GV7j1bSmQQAi26X+GgWcTjLr/0tzSvMCl3LH1w1IJ4PFSPoV5316b30cneTziC+B1a+3OjoSUcQYmw==
   dependencies:
-    mime-db ">= 1.38.0 < 2"
+    mime-db ">= 1.40.0 < 2"
 
 compression@^1.5.2:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/compression/-/compression-1.7.3.tgz#27e0e176aaf260f7f2c2813c3e440adb9f1993db"
-  integrity sha512-HSjyBG5N1Nnz7tF2+O7A9XUhyjru71/fwgNb7oIsEVHR0WShfs2tIS/EySLgiTe98aOK18YDlMXpzjCXY/n9mg==
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/compression/-/compression-1.7.4.tgz#95523eff170ca57c29a0ca41e6fe131f41e5bb8f"
+  integrity sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==
   dependencies:
     accepts "~1.3.5"
     bytes "3.0.0"
-    compressible "~2.0.14"
+    compressible "~2.0.16"
     debug "2.6.9"
-    on-headers "~1.0.1"
+    on-headers "~1.0.2"
     safe-buffer "5.1.2"
     vary "~1.1.2"
 
@@ -2414,10 +2509,10 @@ concat-stream@^1.5.0:
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
 
-confusing-browser-globals@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/confusing-browser-globals/-/confusing-browser-globals-1.0.5.tgz#0171050cfdd4261e278978078bc00c4d88e135f4"
-  integrity sha512-tHo1tQL/9Ox5RELbkCAJhnViqWlzBz3MG1bB2czbHjH2mWd4aYUgNCNLfysFL7c4LoDws7pjg2tj48Gmpw4QHA==
+confusing-browser-globals@^1.0.6:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/confusing-browser-globals/-/confusing-browser-globals-1.0.7.tgz#5ae852bd541a910e7ffb2dbb864a2d21a36ad29b"
+  integrity sha512-cgHI1azax5ATrZ8rJ+ODDML9Fvu67PimB6aNxBrc/QwSaDaM9eTfIEUHx3bBLJJ82ioSb+/5zfsMCCEJax3ByQ==
 
 connect-history-api-fallback@^1.3.0:
   version "1.6.0"
@@ -2490,10 +2585,30 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
+core-js-compat@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.0.1.tgz#bff73ba31ca8687431b9c88f78d3362646fb76f0"
+  integrity sha512-2pC3e+Ht/1/gD7Sim/sqzvRplMiRnFQVlPpDVaHtY9l7zZP7knamr3VRD6NyGfHd84MrDC0tAM9ulNxYMW0T3g==
+  dependencies:
+    browserslist "^4.5.4"
+    core-js "3.0.1"
+    core-js-pure "3.0.1"
+    semver "^6.0.0"
+
+core-js-pure@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.0.1.tgz#37358fb0d024e6b86d443d794f4e37e949098cbe"
+  integrity sha512-mSxeQ6IghKW3MoyF4cz19GJ1cMm7761ON+WObSyLfTu/Jn3x7w4NwNFnrZxgl4MTSvYYepVLNuRtlB4loMwJ5g==
+
 core-js@2.6.4:
   version "2.6.4"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.4.tgz#b8897c062c4d769dd30a0ac5c73976c47f92ea0d"
   integrity sha512-05qQ5hXShcqGkPZpXEFLIpxayZscVD2kuMBZewxiIPPEagukO4mqgPA9CWhUvFBJfy3ODdK2p9xyHh7FTU9/7A==
+
+core-js@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.0.1.tgz#1343182634298f7f38622f95e73f54e48ddf4738"
+  integrity sha512-sco40rF+2KlE0ROMvydjkrVMMG1vYilP2ALoRXcYR4obqbYIuV3Bg+51GEDW+HF8n7NRA+iaA4qD0nD9lo9mew==
 
 core-js@^1.0.0:
   version "1.2.7"
@@ -2520,15 +2635,14 @@ cosmiconfig@^4.0.0:
     parse-json "^4.0.0"
     require-from-string "^2.0.1"
 
-cosmiconfig@^5.0.0, cosmiconfig@^5.0.5, cosmiconfig@^5.0.7:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.1.0.tgz#6c5c35e97f37f985061cdf653f114784231185cf"
-  integrity sha512-kCNPvthka8gvLtzAxQXvWo4FxqRB+ftRZyPZNuab5ngvM9Y7yw7hbEysglptLgpkGX9nAOKTBVkHUAe8xtYR6Q==
+cosmiconfig@^5.0.0, cosmiconfig@^5.0.5, cosmiconfig@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.2.0.tgz#45038e4d28a7fe787203aede9c25bca4a08b12c8"
+  integrity sha512-nxt+Nfc3JAqf4WIWd0jXLjTJZmsPLrA9DDc4nRw2KFJQJK7DNooqSXrNI7tzLG50CF8axczly5UV929tBmh/7g==
   dependencies:
     import-fresh "^2.0.0"
     is-directory "^0.3.1"
-    js-yaml "^3.9.0"
-    lodash.get "^4.4.2"
+    js-yaml "^3.13.0"
     parse-json "^4.0.0"
 
 create-ecdh@^4.0.0:
@@ -2660,7 +2774,7 @@ css-prefers-color-scheme@^3.1.1:
   dependencies:
     postcss "^7.0.5"
 
-css-select-base-adapter@~0.1.0:
+css-select-base-adapter@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz#3b2ff4972cc362ab88561507a95408a1432135d7"
   integrity sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w==
@@ -2726,9 +2840,9 @@ css-what@2.1, css-what@^2.1.2:
   integrity sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==
 
 cssdb@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/cssdb/-/cssdb-4.3.0.tgz#2e1229900616f80c66ff2d568ea2b4f92db1c78c"
-  integrity sha512-VHPES/+c9s+I0ryNj+PXvp84nz+ms843z/efpaEINwP/QfGsINL3gpLp5qjapzDNzNzbXxur8uxKxSXImrg4ag==
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/cssdb/-/cssdb-4.4.0.tgz#3bf2f2a68c10f5c6a08abd92378331ee803cddb0"
+  integrity sha512-LsTAR1JPEM9TpGhl/0p3nQecC2LJ0kD8X5YARu1hk/9I1gril5vDtMZyNxcEpxxDj34YNck/ucjuoUd66K03oQ==
 
 cssesc@^0.1.0:
   version "0.1.0"
@@ -2808,7 +2922,7 @@ cssnano@^4.1.0:
     is-resolvable "^1.0.0"
     postcss "^7.0.0"
 
-csso@^3.5.0:
+csso@^3.5.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/csso/-/csso-3.5.1.tgz#7b9eb8be61628973c1b261e169d2f024008e758b"
   integrity sha512-vrqULLffYU1Q2tLdJvaCYbONStnfkfimRxXNaGjxMldI0C7JPBC4rB1RyjhfdZ4m1frm8pM9uRPKH3d2knZ8gg==
@@ -2821,9 +2935,9 @@ cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   integrity sha512-DtUeseGk9/GBW0hl0vVPpU22iHL6YB5BUX7ml1hB+GMpo0NX5G4voX3kdWiMSEguFtcW3Vh3djqNF4aIe6ne0A==
 
 cssstyle@^1.0.0:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-1.2.1.tgz#3aceb2759eaf514ac1a21628d723d6043a819495"
-  integrity sha512-7DYm8qe+gPx/h77QlCyFmX80+fGaE/6A/Ekl0zaszYOubvySO2saYFdQ78P29D0UsULxFKCetDGNaNRUdSF+2A==
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-1.2.2.tgz#427ea4d585b18624f6fdbf9de7a2a1a3ba713077"
+  integrity sha512-43wY3kl1CVQSvL7wUY1qXkxVGkStjpkDmVjiIKX8R97uhajy8Bybay78uOtqvh7Q5GK75dNPfW0geWjE6qQQow==
   dependencies:
     cssom "0.3.x"
 
@@ -2833,9 +2947,9 @@ cyclist@~0.2.2:
   integrity sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=
 
 damerau-levenshtein@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.4.tgz#03191c432cb6eea168bb77f3a55ffdccb8978514"
-  integrity sha1-AxkcQyy27qFou3fzpV/9zLiXhRQ=
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.5.tgz#780cf7144eb2e8dbd1c3bb83ae31100ccc31a414"
+  integrity sha512-CBCRqFnpu715iPmw1KrdOrzRqbdFwQTwAWyyyYS42+iAgHCuXZ+/TdMgQkUENPomxEz9z1BEzuQU2Xw0kUuAgA==
 
 dashdash@^1.12.0:
   version "1.14.1"
@@ -2863,7 +2977,7 @@ date-now@^0.1.4:
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
   integrity sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=
 
-debug@2.6.9, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.8, debug@^2.6.9:
+debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
@@ -3187,10 +3301,10 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
-electron-to-chromium@^1.3.103, electron-to-chromium@^1.3.113:
-  version "1.3.113"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.113.tgz#b1ccf619df7295aea17bc6951dc689632629e4a9"
-  integrity sha512-De+lPAxEcpxvqPTyZAXELNpRZXABRxf+uL/rSykstQhzj/B0l1150G/ExIIxKc16lI89Hgz81J0BHAcbTqK49g==
+electron-to-chromium@^1.3.103, electron-to-chromium@^1.3.127:
+  version "1.3.133"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.133.tgz#c47639c19b91feee3e22fad69f5556142007008c"
+  integrity sha512-lyoC8aoqbbDqsprb6aPdt9n3DpOZZzdz/T4IZKsR0/dkZIxnJVUjjcpOSwA66jPRIOyDAamCTAUqweU05kKNSg==
 
 elliptic@^6.0.0:
   version "6.4.1"
@@ -3310,12 +3424,12 @@ escodegen@^1.9.1:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-config-react-app@^3.0.7:
-  version "3.0.7"
-  resolved "https://registry.yarnpkg.com/eslint-config-react-app/-/eslint-config-react-app-3.0.7.tgz#d58c9216ff285e2b4de0eb8403c28b0600e45b3e"
-  integrity sha512-Mmmc9lIY/qvX6OEV09+ZLqVTz1aX8VVCrgCjBHXdmMGaC+pldD+87oj3BiJWXMSfcYs5iOo9gy0mGnQ8f/fMsQ==
+eslint-config-react-app@^3.0.8:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/eslint-config-react-app/-/eslint-config-react-app-3.0.8.tgz#6f606828ba30bafee7d744c41cd07a3fea8f3035"
+  integrity sha512-Ovi6Bva67OjXrom9Y/SLJRkrGqKhMAL0XCH8BizPhjEVEhYczl2ZKiNZI2CuqO5/CJwAfMwRXAVGY0KToWr1aA==
   dependencies:
-    confusing-browser-globals "^1.0.5"
+    confusing-browser-globals "^1.0.6"
 
 eslint-import-resolver-node@^0.3.1:
   version "0.3.2"
@@ -3337,9 +3451,9 @@ eslint-loader@2.1.1:
     rimraf "^2.6.1"
 
 eslint-module-utils@^2.2.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.3.0.tgz#546178dab5e046c8b562bbb50705e2456d7bda49"
-  integrity sha512-lmDJgeOOjk8hObTysjqH7wyMi+nsHwwvfBykwfhjR1LNdd7C2uFJBvx4OpWYpXOw4df1yE1cDEVd1yLHitk34w==
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.4.0.tgz#8b93499e9b00eab80ccb6614e69f03678e84e09a"
+  integrity sha512-14tltLm38Eu3zS+mt0KvILC3q8jyIAH518MlG+HO0p+yK885Lb1UHTY/UgR91eOyGdmxAPb+OLoW4znqIT6Ndw==
   dependencies:
     debug "^2.6.8"
     pkg-dir "^2.0.0"
@@ -3394,6 +3508,19 @@ eslint-plugin-react@7.12.4:
     prop-types "^15.6.2"
     resolve "^1.9.0"
 
+eslint-plugin-react@^7.13.0:
+  version "7.13.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.13.0.tgz#bc13fd7101de67996ea51b33873cd9dc2b7e5758"
+  integrity sha512-uA5LrHylu8lW/eAH3bEQe9YdzpPaFd9yAJTwTi/i/BKTD7j6aQMKVAdGM/ML72zD6womuSK7EiGtMKuK06lWjQ==
+  dependencies:
+    array-includes "^3.0.3"
+    doctrine "^2.1.0"
+    has "^1.0.3"
+    jsx-ast-utils "^2.1.0"
+    object.fromentries "^2.0.0"
+    prop-types "^15.7.2"
+    resolve "^1.10.1"
+
 eslint-scope@3.7.1:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.1.tgz#3d63c3edfda02e06e01a452ad88caacc7cdcb6e8"
@@ -3403,9 +3530,9 @@ eslint-scope@3.7.1:
     estraverse "^4.1.1"
 
 eslint-scope@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.0.tgz#50bf3071e9338bcdc43331794a0cb533f0136172"
-  integrity sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.3.tgz#ca03833310f6889a3264781aa82e63eb9cfe7848"
+  integrity sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==
   dependencies:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
@@ -3512,9 +3639,9 @@ etag@~1.8.1:
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
 
 eventemitter3@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.0.tgz#090b4d6cdbd645ed10bf750d4b5407942d7ba163"
-  integrity sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA==
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.2.tgz#2d3d48f9c346698fce83a85d7d664e98535df6e7"
+  integrity sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==
 
 events@^3.0.0:
   version "3.0.0"
@@ -3883,12 +4010,12 @@ find-cache-dir@^0.1.1:
     pkg-dir "^1.0.0"
 
 find-cache-dir@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-2.0.0.tgz#4c1faed59f45184530fb9d7fa123a4d04a98472d"
-  integrity sha512-LDUY6V1Xs5eFskUVYtIwatojt6+9xC9Chnlk/jYOOvn3FAFfSaWddxahDGyNHh0b2dMXa6YW2m0tk8TdVaXHlA==
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-2.1.0.tgz#8d0f94cd13fe43c6c7c261a0d86115ca918c05f7"
+  integrity sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==
   dependencies:
     commondir "^1.0.1"
-    make-dir "^1.0.0"
+    make-dir "^2.0.0"
     pkg-dir "^3.0.0"
 
 find-up@3.0.0, find-up@^3.0.0:
@@ -3972,18 +4099,17 @@ forever-agent@~0.6.1:
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
 
-fork-ts-checker-webpack-plugin-alt@0.4.14:
-  version "0.4.14"
-  resolved "https://registry.yarnpkg.com/fork-ts-checker-webpack-plugin-alt/-/fork-ts-checker-webpack-plugin-alt-0.4.14.tgz#1bd6c0d97b7d4682dde61255fcbd78b72f7473a0"
-  integrity sha512-s0wjOBuPdylMRBzZ4yO8LSJuzem3g0MYZFxsjRXrFDQyL5KJBVSq30+GoHM/t/r2CRU4tI6zi04sq6OXK0UYnw==
+fork-ts-checker-webpack-plugin@1.0.0-alpha.6:
+  version "1.0.0-alpha.6"
+  resolved "https://registry.yarnpkg.com/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-1.0.0-alpha.6.tgz#826c57048addf8a3253853615c84f3ff7beeaf45"
+  integrity sha512-s/V+58nLrUjuXyzYk8AL11XG8bxIirTbafDLMn26sL59HQx8QvvsRTqOkhq4MV0coIkog1jZuH/E9Abm8zFZ2g==
   dependencies:
     babel-code-frame "^6.22.0"
     chalk "^2.4.1"
     chokidar "^2.0.4"
-    lodash "^4.17.11"
     micromatch "^3.1.10"
     minimatch "^3.0.4"
-    resolve "^1.5.0"
+    semver "^5.6.0"
     tapable "^1.0.0"
 
 form-data@~2.3.2:
@@ -4069,12 +4195,12 @@ fsevents@1.2.4:
     node-pre-gyp "^0.10.0"
 
 fsevents@^1.2.3, fsevents@^1.2.7:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.7.tgz#4851b664a3783e52003b3c66eb0eee1074933aa4"
-  integrity sha512-Pxm6sI2MeBD7RdD12RYsqaP0nMiwx8eZBXCa6z2L+mRHm2DYrOYwihmhjpkdjUHwQhslWQjRpEgNq4XvBmaAuw==
+  version "1.2.9"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.9.tgz#3f5ed66583ccd6f400b5a00db6f7e861363e388f"
+  integrity sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==
   dependencies:
-    nan "^2.9.2"
-    node-pre-gyp "^0.10.0"
+    nan "^2.12.1"
+    node-pre-gyp "^0.12.0"
 
 function-bind@^1.1.1:
   version "1.1.1"
@@ -4163,9 +4289,9 @@ glob-to-regexp@^0.3.0:
   integrity sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=
 
 glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
-  version "7.1.3"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
-  integrity sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.4.tgz#aa608a2f6c577ad357e1ae5a5c26d9a8d1969255"
+  integrity sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -4191,9 +4317,9 @@ global-prefix@^3.0.0:
     which "^1.3.1"
 
 globals@^11.1.0, globals@^11.7.0:
-  version "11.11.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-11.11.0.tgz#dcf93757fa2de5486fbeed7118538adf789e9c2e"
-  integrity sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw==
+  version "11.12.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
+  integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
 globals@^9.18.0:
   version "9.18.0"
@@ -4253,11 +4379,11 @@ handle-thing@^2.0.0:
   integrity sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ==
 
 handlebars@^4.0.3:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.1.0.tgz#0d6a6f34ff1f63cecec8423aa4169827bf787c3a"
-  integrity sha512-l2jRuU1NAWK6AW5qqcTATWQJvNPEwkM7NEKSiv/gqOsoSQbVoWyqVEY5GS+XPQ88zLNmqASRpzfdm8d79hJS+w==
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.1.2.tgz#b6b37c1ced0306b221e094fc7aca3ec23b131b67"
+  integrity sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==
   dependencies:
-    async "^2.5.0"
+    neo-async "^2.6.0"
     optimist "^0.6.1"
     source-map "^0.6.1"
   optionalDependencies:
@@ -4399,15 +4525,16 @@ hex-color-regex@^1.1.0:
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
 
 history@^4.7.2:
-  version "4.7.2"
-  resolved "https://registry.yarnpkg.com/history/-/history-4.7.2.tgz#22b5c7f31633c5b8021c7f4a8a954ac139ee8d5b"
-  integrity sha512-1zkBRWW6XweO0NBcjiphtVJVsIQ+SXF29z9DVkceeaSLVMFXHool+fdCZD4spDCfZJCILPILc3bm7Bc+HRi0nA==
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/history/-/history-4.9.0.tgz#84587c2068039ead8af769e9d6a6860a14fa1bca"
+  integrity sha512-H2DkjCjXf0Op9OAr6nJ56fcRkTSNrUiv41vNJ6IswJjif6wlpZK0BTfFbi7qK9dXLSYZxkq5lBsj3vUjlYBYZA==
   dependencies:
-    invariant "^2.2.1"
+    "@babel/runtime" "^7.1.2"
     loose-envify "^1.2.0"
     resolve-pathname "^2.2.0"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
     value-equal "^0.4.0"
-    warning "^3.0.0"
 
 hmac-drbg@^1.0.0:
   version "1.0.1"
@@ -4608,9 +4735,9 @@ identity-obj-proxy@3.0.0:
     harmony-reflect "^1.4.6"
 
 ieee754@^1.1.4:
-  version "1.1.12"
-  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.12.tgz#50bf24e5b9c8bb98af4964c941cdb0918da7b60b"
-  integrity sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA==
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
+  integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
 
 iferr@^0.1.5:
   version "0.1.5"
@@ -4743,9 +4870,9 @@ inquirer@6.2.1:
     through "^2.3.6"
 
 inquirer@^6.1.0:
-  version "6.2.2"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.2.2.tgz#46941176f65c9eb20804627149b743a218f25406"
-  integrity sha512-Z2rREiXA6cHRR9KBOarR3WuLlFzlIfAEIiB45ll5SSadMg7WqOh1MKEjjndfuH5ewXdixWCxqnVfGOQzPeiztA==
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.3.1.tgz#7a413b5e7950811013a3db491c61d1f3b776e8e7"
+  integrity sha512-MmL624rfkFt4TG9y/Jvmt8vdmOo836U7Y0Hxr2aFk3RelZEGX4Igk0KabWrcaaZaTv9uzglOqWh1Vly+FAWAXA==
   dependencies:
     ansi-escapes "^3.2.0"
     chalk "^2.4.2"
@@ -4758,7 +4885,7 @@ inquirer@^6.1.0:
     run-async "^2.2.0"
     rxjs "^6.4.0"
     string-width "^2.1.0"
-    strip-ansi "^5.0.0"
+    strip-ansi "^5.1.0"
     through "^2.3.6"
 
 internal-ip@^3.0.1:
@@ -4769,7 +4896,7 @@ internal-ip@^3.0.1:
     default-gateway "^2.6.0"
     ipaddr.js "^1.5.2"
 
-invariant@^2.2.1, invariant@^2.2.2, invariant@^2.2.4:
+invariant@^2.2.2, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
@@ -4796,12 +4923,7 @@ ip@^1.1.0, ip@^1.1.5:
   resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
   integrity sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=
 
-ipaddr.js@1.8.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.8.0.tgz#eaa33d6ddd7ace8f7f6fe0c9ca0440e706738b1e"
-  integrity sha1-6qM9bd16zo9/b+DJygRA5wZzix4=
-
-ipaddr.js@^1.5.2:
+ipaddr.js@1.9.0, ipaddr.js@^1.5.2:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.0.tgz#37df74e430a0e47550fe54a2defe30d8acd95f65"
   integrity sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA==
@@ -4991,9 +5113,9 @@ is-glob@^3.1.0:
     is-extglob "^2.1.0"
 
 is-glob@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.0.tgz#9521c76845cc2610a85203ddf080a958c2ffabc0"
-  integrity sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc"
+  integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
   dependencies:
     is-extglob "^2.1.1"
 
@@ -5588,15 +5710,10 @@ joi@^11.1.1:
     isemail "3.x.x"
     topo "2.x.x"
 
-jquery@^3.4.0:
+jquery@^3.4.0, jquery@x.*:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
   integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==
-
-jquery@x.*:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.3.1.tgz#958ce29e81c9790f31be7792df5d4d95fc57fbca"
-  integrity sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg==
 
 js-levenshtein@^1.1.3:
   version "1.1.6"
@@ -5613,10 +5730,10 @@ js-tokens@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
-js-yaml@^3.12.0, js-yaml@^3.7.0, js-yaml@^3.9.0:
-  version "3.12.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.1.tgz#295c8632a18a23e054cf5c9d3cecafe678167600"
-  integrity sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==
+js-yaml@^3.12.0, js-yaml@^3.13.0, js-yaml@^3.13.1, js-yaml@^3.7.0, js-yaml@^3.9.0:
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
+  integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
@@ -5751,10 +5868,10 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
-jsx-ast-utils@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz#e801b1b39985e20fffc87b40e3748080e2dcac7f"
-  integrity sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=
+jsx-ast-utils@^2.0.1, jsx-ast-utils@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-2.1.0.tgz#0ee4e2c971fb9601c67b5641b71be80faecf0b36"
+  integrity sha512-yDGDG2DS4JcqhA6blsuYbtsT09xL8AoLuUR2Gb5exrw7UEM19sBcOTq+YBBhrNbl0PUC4R4LnFu+dHg2HKeVvA==
   dependencies:
     array-includes "^3.0.3"
 
@@ -5876,9 +5993,9 @@ load-json-file@^2.0.0:
     strip-bom "^3.0.0"
 
 loader-fs-cache@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/loader-fs-cache/-/loader-fs-cache-1.0.1.tgz#56e0bf08bd9708b26a765b68509840c8dec9fdbc"
-  integrity sha1-VuC/CL2XCLJqdltoUJhAyN7J/bw=
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/loader-fs-cache/-/loader-fs-cache-1.0.2.tgz#54cedf6b727e1779fd8f01205f05f6e88706f086"
+  integrity sha512-70IzT/0/L+M20jUlEqZhZyArTU6VKLRTYRDAYN26g4jfzpJqjipLL3/hgYpySqI9PwsVRHHFja0LfEmsx9X2Cw==
   dependencies:
     find-cache-dir "^0.1.1"
     mkdirp "0.5.1"
@@ -5922,11 +6039,6 @@ lodash.camelcase@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
   integrity sha1-soqmKIorn8ZRA1x3EfZathkDMaY=
-
-lodash.get@^4.4.2:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
-  integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
 
 lodash.memoize@^4.1.2:
   version "4.1.2"
@@ -6000,12 +6112,13 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
-make-dir@^1.0.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.3.0.tgz#79c1033b80515bd6d24ec9933e860ca75ee27f0c"
-  integrity sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==
+make-dir@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-2.1.0.tgz#5f0310e18b8be898cc07009295a30ae41e91e6f5"
+  integrity sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==
   dependencies:
-    pify "^3.0.0"
+    pify "^4.0.1"
+    semver "^5.6.0"
 
 makeerror@1.0.x:
   version "1.0.11"
@@ -6065,12 +6178,12 @@ mem@^1.1.0:
     mimic-fn "^1.0.0"
 
 mem@^4.0.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/mem/-/mem-4.1.0.tgz#aeb9be2d21f47e78af29e4ac5978e8afa2ca5b8a"
-  integrity sha512-I5u6Q1x7wxO0kdOpYBB28xueHADYps5uty/zg936CiG8NTe5sJL8EjrCuLneuDW3PlMdZBGDIn8BirEVdovZvg==
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/mem/-/mem-4.3.0.tgz#461af497bc4ae09608cdb2e60eefb69bff744178"
+  integrity sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==
   dependencies:
     map-age-cleaner "^0.1.1"
-    mimic-fn "^1.0.0"
+    mimic-fn "^2.0.0"
     p-is-promise "^2.0.0"
 
 memory-fs@^0.4.0, memory-fs@~0.4.1:
@@ -6163,17 +6276,17 @@ miller-rabin@^4.0.0:
     bn.js "^4.0.0"
     brorand "^1.0.1"
 
-"mime-db@>= 1.38.0 < 2", mime-db@~1.38.0:
-  version "1.38.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.38.0.tgz#1a2aab16da9eb167b49c6e4df2d9c68d63d8e2ad"
-  integrity sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg==
+mime-db@1.40.0, "mime-db@>= 1.40.0 < 2":
+  version "1.40.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.40.0.tgz#a65057e998db090f732a68f6c276d387d4126c32"
+  integrity sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==
 
-mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.18, mime-types@~2.1.19:
-  version "2.1.22"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.22.tgz#fe6b355a190926ab7698c9a0556a11199b2199bd"
-  integrity sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==
+mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.19, mime-types@~2.1.24:
+  version "2.1.24"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.24.tgz#b6f8d0b3e951efb77dedeca194cff6d16f676f81"
+  integrity sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==
   dependencies:
-    mime-db "~1.38.0"
+    mime-db "1.40.0"
 
 mime@1.4.1:
   version "1.4.1"
@@ -6181,14 +6294,19 @@ mime@1.4.1:
   integrity sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==
 
 mime@^2.0.3, mime@^2.3.1:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.0.tgz#e051fd881358585f3279df333fe694da0bcffdd6"
-  integrity sha512-ikBcWwyqXQSHKtciCcctu9YfPbFYZ4+gbHEmE0Q8jzcTYQg5dHCr3g2wwAZjPoJfQVXZq6KXAjpXOTf5/cjT7w==
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.2.tgz#ce5229a5e99ffc313abac806b482c10e7ba6ac78"
+  integrity sha512-zJBfZDkwRu+j3Pdd2aHsR5GfH2jIWhmL1ZzBoc+X+3JEti2hbArWcyJ+1laC1D2/U/W1a/+Cegj0/OnEU2ybjg==
 
 mimic-fn@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
   integrity sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==
+
+mimic-fn@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
+  integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
 mini-css-extract-plugin@0.5.0:
   version "0.5.0"
@@ -6325,10 +6443,10 @@ mute-stream@0.0.7:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
   integrity sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
 
-nan@^2.9.2:
-  version "2.12.1"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.12.1.tgz#7b1aa193e9aa86057e3c7bbd0ac448e770925552"
-  integrity sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw==
+nan@^2.12.1, nan@^2.9.2:
+  version "2.13.2"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.13.2.tgz#f51dc7ae66ba7d5d55e1e6d4d8092e802c9aefe7"
+  integrity sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -6353,20 +6471,20 @@ natural-compare@^1.4.0:
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
 needle@^2.2.1:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/needle/-/needle-2.2.4.tgz#51931bff82533b1928b7d1d69e01f1b00ffd2a4e"
-  integrity sha512-HyoqEb4wr/rsoaIDfTH2aVL9nWtQqba2/HvMv+++m8u0dz808MaagKILxtfeSN7QU7nvbQ79zk3vYOJp9zsNEA==
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/needle/-/needle-2.3.1.tgz#d272f2f4034afb9c4c9ab1379aabc17fc85c9388"
+  integrity sha512-CaLXV3W8Vnbps8ZANqDGz7j4x7Yj1LW4TWF/TQuDfj7Cfx4nAPTvw98qgTevtto1oHDrh3pQkaODbqupXlsWTg==
   dependencies:
-    debug "^2.1.2"
+    debug "^4.1.0"
     iconv-lite "^0.4.4"
     sax "^1.2.4"
 
-negotiator@0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
-  integrity sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=
+negotiator@0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
+  integrity sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==
 
-neo-async@^2.5.0:
+neo-async@^2.5.0, neo-async@^2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.0.tgz#b9d15e4d71c6762908654b5183ed38b753340835"
   integrity sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==
@@ -6457,10 +6575,26 @@ node-pre-gyp@^0.10.0:
     semver "^5.3.0"
     tar "^4"
 
-node-releases@^1.1.3, node-releases@^1.1.8:
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.8.tgz#32a63fff63c5e51b7e0f540ac95947d220fc6862"
-  integrity sha512-gQm+K9mGCiT/NXHy+V/ZZS1N/LOaGGqRAAJJs3X9Ah1g+CIbRcBgNyoNYQ+SEtcyAtB9KqDruu+fF7nWjsqRaA==
+node-pre-gyp@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz#39ba4bb1439da030295f899e3b520b7785766149"
+  integrity sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==
+  dependencies:
+    detect-libc "^1.0.2"
+    mkdirp "^0.5.1"
+    needle "^2.2.1"
+    nopt "^4.0.1"
+    npm-packlist "^1.1.6"
+    npmlog "^4.0.2"
+    rc "^1.2.7"
+    rimraf "^2.6.1"
+    semver "^5.3.0"
+    tar "^4"
+
+node-releases@^1.1.17, node-releases@^1.1.3:
+  version "1.1.18"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.18.tgz#cc98fd75598a324a77188ebddf6650e9cbd8b1d5"
+  integrity sha512-/mnVgm6u/8OwlIsoyRXtTI0RfQcxZoAZbdwyXap0EeWwcOpDDymyCHM2/aR9XKmHXrvizHoPAOs0pcbiJ6RUaA==
   dependencies:
     semver "^5.3.0"
 
@@ -6552,9 +6686,9 @@ number-is-nan@^1.0.0:
   integrity sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=
 
 nwsapi@^2.0.7:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.1.0.tgz#781065940aed90d9bb01ca5d0ce0fcf81c32712f"
-  integrity sha512-ZG3bLAvdHmhIjaQ/Db1qvBxsGvFMLIRpQszyqbg31VJ53UP++uZX1/gf3Ut96pdwN9AuDwlMqIYLm0UPCdUeHg==
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.1.4.tgz#e006a878db23636f8e8a67d33ca0e4edf61a842f"
+  integrity sha512-iGfd9Y6SFdTNldEy2L0GUhcarIutFmk+MPWIn9dmj8NMIup03G08uUF2KGbbmv/Ux4RT0VZJoP/sVbWA6d/VIw==
 
 oauth-sign@~0.9.0:
   version "0.9.0"
@@ -6581,9 +6715,9 @@ object-hash@^1.1.4:
   integrity sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA==
 
 object-keys@^1.0.11, object-keys@^1.0.12:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.0.tgz#11bd22348dd2e096a045ab06f6c85bcc340fa032"
-  integrity sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg==
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
+  integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
 
 object-visit@^1.0.0:
   version "1.0.1"
@@ -6635,7 +6769,7 @@ object.pick@^1.3.0:
   dependencies:
     isobject "^3.0.1"
 
-object.values@^1.0.4:
+object.values@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/object.values/-/object.values-1.1.0.tgz#bf6810ef5da3e5325790eaaa2be213ea84624da9"
   integrity sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==
@@ -6657,7 +6791,7 @@ on-finished@~2.3.0:
   dependencies:
     ee-first "1.1.1"
 
-on-headers@~1.0.1:
+on-headers@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/on-headers/-/on-headers-1.0.2.tgz#772b0ae6aaa525c399e489adfad90c403eb3c28f"
   integrity sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==
@@ -6676,10 +6810,17 @@ onetime@^2.0.0:
   dependencies:
     mimic-fn "^1.0.0"
 
-opn@5.4.0, opn@^5.1.0:
+opn@5.4.0:
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/opn/-/opn-5.4.0.tgz#cb545e7aab78562beb11aa3bfabc7042e1761035"
   integrity sha512-YF9MNdVy/0qvJvDtunAOzFw9iasOQHpVthTCvGzxt61Il64AYSGdK+rYwld7NAfk9qJ7dt+hymBNSc9LNYS+Sw==
+  dependencies:
+    is-wsl "^1.1.0"
+
+opn@^5.1.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/opn/-/opn-5.5.0.tgz#fc7164fab56d235904c51c3b27da6758ca3b9bfc"
+  integrity sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==
   dependencies:
     is-wsl "^1.1.0"
 
@@ -6770,9 +6911,9 @@ p-finally@^1.0.0:
   integrity sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=
 
 p-is-promise@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-2.0.0.tgz#7554e3d572109a87e1f3f53f6a7d85d1b194f4c5"
-  integrity sha512-pzQPhYMCAgLAKPWD2jC3Se9fEfrD9npNos0y150EeqZll7akhEgGhTW/slB6lHku8AvYGiJ+YJ5hfHKePPgFWg==
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-2.1.0.tgz#918cebaea248a62cf7ffab8e3bca8c5f882fc42e"
+  integrity sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==
 
 p-limit@^1.1.0:
   version "1.3.0"
@@ -6782,9 +6923,9 @@ p-limit@^1.1.0:
     p-try "^1.0.0"
 
 p-limit@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.1.0.tgz#1d5a0d20fb12707c758a655f6bbc4386b5930d68"
-  integrity sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.0.tgz#417c9941e6027a9abcba5092dd2904e255b5fbc2"
+  integrity sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==
   dependencies:
     p-try "^2.0.0"
 
@@ -6813,14 +6954,14 @@ p-try@^1.0.0:
   integrity sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=
 
 p-try@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.0.0.tgz#85080bb87c64688fa47996fe8f7dfbe8211760b1"
-  integrity sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
+  integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
 pako@~1.0.5:
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.8.tgz#6844890aab9c635af868ad5fecc62e8acbba3ea4"
-  integrity sha512-6i0HVbUfcKaTv+EG8ZTr75az7GFXcLYk9UyLEg7Notv/Ma+z/UG3TCoz6GiNeOrn1E/e63I0X/Hpw18jHOTUnA==
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.10.tgz#4328badb5086a426aa90f541977d4955da5c9732"
+  integrity sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==
 
 parallel-transform@^1.1.0:
   version "1.1.0"
@@ -6839,9 +6980,9 @@ param-case@2.1.x:
     no-case "^2.2.0"
 
 parent-module@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.0.tgz#df250bdc5391f4a085fb589dad761f5ad6b865b5"
-  integrity sha512-8Mf5juOMmiE4FcmzYc4IaiS9L3+9paz2KOiXzkRviCP6aDmN49Hz6EMWz0lGNp9pX80GvvAuLADtyGfW/Em3TA==
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
+  integrity sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==
   dependencies:
     callsites "^3.0.0"
 
@@ -6893,9 +7034,9 @@ parse5@^5.0.0:
   integrity sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==
 
 parseurl@~1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.2.tgz#fc289d4ed8993119460c156253262cdc8de65bf3"
-  integrity sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
+  integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
 
 pascalcase@^0.1.1:
   version "0.1.1"
@@ -7004,6 +7145,11 @@ pify@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
   integrity sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=
+
+pify@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
+  integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
 
 pinkie-promise@^2.0.0:
   version "2.0.1"
@@ -7117,12 +7263,12 @@ postcss-color-gray@^5.0.0:
     postcss-values-parser "^2.0.0"
 
 postcss-color-hex-alpha@^5.0.2:
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/postcss-color-hex-alpha/-/postcss-color-hex-alpha-5.0.2.tgz#e9b1886bb038daed33f6394168c210b40bb4fdb6"
-  integrity sha512-8bIOzQMGdZVifoBQUJdw+yIY00omBd2EwkJXepQo9cjp1UOHHHoeRDeSzTP6vakEpaRc6GAIOfvcQR7jBYaG5Q==
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/postcss-color-hex-alpha/-/postcss-color-hex-alpha-5.0.3.tgz#a8d9ca4c39d497c9661e374b9c51899ef0f87388"
+  integrity sha512-PF4GDel8q3kkreVXKLAGNpHKilXsZ6xuu+mOQMHWHLPNyjiUBOr75sp5ZKJfmv1MCus5/DWUGcK9hm6qHEnXYw==
   dependencies:
-    postcss "^7.0.2"
-    postcss-values-parser "^2.0.0"
+    postcss "^7.0.14"
+    postcss-values-parser "^2.0.1"
 
 postcss-color-mod-function@^3.0.3:
   version "3.0.3"
@@ -7161,19 +7307,19 @@ postcss-convert-values@^4.0.1:
     postcss-value-parser "^3.0.0"
 
 postcss-custom-media@^7.0.7:
-  version "7.0.7"
-  resolved "https://registry.yarnpkg.com/postcss-custom-media/-/postcss-custom-media-7.0.7.tgz#bbc698ed3089ded61aad0f5bfb1fb48bf6969e73"
-  integrity sha512-bWPCdZKdH60wKOTG4HKEgxWnZVjAIVNOJDvi3lkuTa90xo/K0YHa2ZnlKLC5e2qF8qCcMQXt0yzQITBp8d0OFA==
+  version "7.0.8"
+  resolved "https://registry.yarnpkg.com/postcss-custom-media/-/postcss-custom-media-7.0.8.tgz#fffd13ffeffad73621be5f387076a28b00294e0c"
+  integrity sha512-c9s5iX0Ge15o00HKbuRuTqNndsJUbaXdiNsksnVH8H4gdc+zbLzr/UasOwNG6CTDpLFekVY4672eWdiiWu2GUg==
   dependencies:
-    postcss "^7.0.5"
+    postcss "^7.0.14"
 
 postcss-custom-properties@^8.0.9:
-  version "8.0.9"
-  resolved "https://registry.yarnpkg.com/postcss-custom-properties/-/postcss-custom-properties-8.0.9.tgz#8943870528a6eae4c8e8d285b6ccc9fd1f97e69c"
-  integrity sha512-/Lbn5GP2JkKhgUO2elMs4NnbUJcvHX4AaF5nuJDaNkd2chYW1KA5qtOGGgdkBEWcXtKSQfHXzT7C6grEVyb13w==
+  version "8.0.10"
+  resolved "https://registry.yarnpkg.com/postcss-custom-properties/-/postcss-custom-properties-8.0.10.tgz#e8dc969e1e15c555f0b836b7f278ef47e3cdeaff"
+  integrity sha512-GDL0dyd7++goDR4SSasYdRNNvp4Gqy1XMzcCnTijiph7VB27XXpJ8bW/AI0i2VSBZ55TpdGhMr37kMSpRfYD0Q==
   dependencies:
-    postcss "^7.0.5"
-    postcss-values-parser "^2.0.0"
+    postcss "^7.0.14"
+    postcss-values-parser "^2.0.1"
 
 postcss-custom-selectors@^5.1.2:
   version "5.1.2"
@@ -7682,7 +7828,7 @@ postcss-value-parser@^3.0.0, postcss-value-parser@^3.3.0, postcss-value-parser@^
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz#9ff822547e2893213cf1c30efa51ac5fd1ba8281"
   integrity sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==
 
-postcss-values-parser@^2.0.0:
+postcss-values-parser@^2.0.0, postcss-values-parser@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/postcss-values-parser/-/postcss-values-parser-2.0.1.tgz#da8b472d901da1e205b47bdc98637b9e9e550e5f"
   integrity sha512-2tLuBsA6P4rYTNKCXYG/71C7j1pU6pK503suYOmn4xYrQIzW+opD+7FAFNuGSdZC/3Qfy334QbeMu7MEb8gOxg==
@@ -7701,9 +7847,9 @@ postcss@^6.0.1, postcss@^6.0.23:
     supports-color "^5.4.0"
 
 postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.2, postcss@^7.0.5, postcss@^7.0.6:
-  version "7.0.14"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.14.tgz#4527ed6b1ca0d82c53ce5ec1a2041c2346bbd6e5"
-  integrity sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==
+  version "7.0.16"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.16.tgz#48f64f1b4b558cb8b52c88987724359acb010da2"
+  integrity sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==
   dependencies:
     chalk "^2.4.2"
     source-map "^0.6.1"
@@ -7787,7 +7933,7 @@ prompts@^0.1.9:
     kleur "^2.0.1"
     sisteransi "^0.1.1"
 
-prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2:
+prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -7804,12 +7950,12 @@ property-information@^5.0.0, property-information@^5.0.1:
     xtend "^4.0.1"
 
 proxy-addr@~2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.4.tgz#ecfc733bf22ff8c6f407fa275327b9ab67e48b93"
-  integrity sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.5.tgz#34cbd64a2d81f4b1fd21e76f9f06c8a45299ee34"
+  integrity sha512-t/7RxHXPH6cJtP0pRG6smSr9QJidhB+3kXu0KgXnbGYMgzEnUxRQ4/LDdfOwZEMyIh3/xHb8PX3t+lfL9z+YVQ==
   dependencies:
     forwarded "~0.1.2"
-    ipaddr.js "1.8.0"
+    ipaddr.js "1.9.0"
 
 prr@~1.0.1:
   version "1.0.1"
@@ -7898,10 +8044,10 @@ querystring@0.2.0:
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
   integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
-querystringify@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.1.0.tgz#7ded8dfbf7879dcc60d0a644ac6754b283ad17ef"
-  integrity sha512-sluvZZ1YiTLD5jsqZcDmFyV2EwToyXZBfpoVOmktMmW+VEnhgakFHnasVph65fOjGPTWN0Nw3+XQaSeMayr0kg==
+querystringify@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.1.1.tgz#60e5a5fd64a7f8bfa4d2ab2ed6fdf4c85bad154e"
+  integrity sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==
 
 raf@3.4.1:
   version "3.4.1"
@@ -7935,9 +8081,9 @@ randomfill@^1.0.3:
     safe-buffer "^5.1.0"
 
 range-parser@^1.0.3, range-parser@~1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
-  integrity sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
+  integrity sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==
 
 raw-body@2.3.3:
   version "2.3.3"
@@ -7959,10 +8105,10 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-app-polyfill@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/react-app-polyfill/-/react-app-polyfill-0.2.1.tgz#96c701a40b9671c8547f70bdbb4a47f4d5767790"
-  integrity sha512-rcpR+WKmLOoYGDAxXaLlxl5Sw6jqbcD1qg2Okn1Ta2RHCxLuQv75B9Em2L2GvuOTx3lAxDpNl/TYGWbKnO/Aag==
+react-app-polyfill@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/react-app-polyfill/-/react-app-polyfill-0.2.2.tgz#a903b61a8bfd9c5e5f16fc63bebe44d6922a44fb"
+  integrity sha512-mAYn96B/nB6kWG87Ry70F4D4rsycU43VYTj3ZCbKP+SLJXwC0x6YCbwcICh3uW8/C9s1VgP197yx+w7SCWeDdQ==
   dependencies:
     core-js "2.6.4"
     object-assign "4.1.1"
@@ -7971,9 +8117,9 @@ react-app-polyfill@^0.2.1:
     whatwg-fetch "3.0.0"
 
 react-datepicker@^2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/react-datepicker/-/react-datepicker-2.4.0.tgz#0965a6004e1e6a3941d80155560b84fe8fc277e6"
-  integrity sha512-ZOY7oYmZt+jeSFGj4NHNdCg7WzzIljPui98lGRd7YHNPO3B8Re4WVNALktp/x+mz1ofNO+TPzodMLMXzqjAUnw==
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/react-datepicker/-/react-datepicker-2.5.0.tgz#67c68b3ffef2eb69b4400913d3cfcfef870be2b3"
+  integrity sha512-X8D+5CqumSUwoq/x5d8O0neYDRmPmwVcyCktVbs5juXV4s73beV6sMf87hM6lxMSanWeB+jpx8waxJcPqsmCIg==
   dependencies:
     classnames "^2.2.5"
     date-fns "^2.0.0-alpha.23"
@@ -7981,10 +8127,10 @@ react-datepicker@^2.4.0:
     react-onclickoutside "^6.7.1"
     react-popper "^1.0.2"
 
-react-dev-utils@^7.0.3:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-7.0.3.tgz#f1316cfffd792fd41b0c28ad5db86c1d74484d6f"
-  integrity sha512-KEFsH1CewnmddPLXIuU+QWKTH/hpJKZClL2+74XN54NkPnR2KnB5gGmuQ0E7DwcCkUpdMxxqBX+rB7aB5sZS4A==
+react-dev-utils@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-8.0.0.tgz#7c5b227a45a32ea8ff7fbc318f336cf9e2c6e34c"
+  integrity sha512-TK8cj7eghvxfe7bfBluLGpI/upo4EXC+G74hYmPucAG8C2XcbT+vKnlWPwLnABb75Zk+mR6D556Da+yvDjljrw==
   dependencies:
     "@babel/code-frame" "7.0.0"
     address "1.0.3"
@@ -7995,6 +8141,7 @@ react-dev-utils@^7.0.3:
     escape-string-regexp "1.0.5"
     filesize "3.6.1"
     find-up "3.0.0"
+    fork-ts-checker-webpack-plugin "1.0.0-alpha.6"
     global-modules "2.0.0"
     globby "8.0.2"
     gzip-size "5.0.0"
@@ -8004,7 +8151,7 @@ react-dev-utils@^7.0.3:
     loader-utils "1.2.3"
     opn "5.4.0"
     pkg-up "2.0.0"
-    react-error-overlay "^5.1.3"
+    react-error-overlay "^5.1.4"
     recursive-readdir "2.2.2"
     shell-quote "1.6.1"
     sockjs-client "1.3.0"
@@ -8012,24 +8159,24 @@ react-dev-utils@^7.0.3:
     text-table "0.2.0"
 
 react-dom@^16.8.3:
-  version "16.8.3"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.3.tgz#ae236029e66210783ac81999d3015dfc475b9c32"
-  integrity sha512-ttMem9yJL4/lpItZAQ2NTFAbV7frotHk5DZEHXUOws2rMmrsvh1Na7ThGT0dTzUIl6pqTOi5tYREfL8AEna3lA==
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.6.tgz#71d6303f631e8b0097f56165ef608f051ff6e10f"
+  integrity sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    scheduler "^0.13.3"
+    scheduler "^0.13.6"
 
-react-error-overlay@^5.1.3:
-  version "5.1.3"
-  resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-5.1.3.tgz#16fcbde75ed4dc6161dc6dc959b48e92c6ffa9ad"
-  integrity sha512-GoqeM3Xadie7XUApXOjkY3Qhs8RkwB/Za4WMedBGrOKH1eTuKGyoAECff7jiVonJchOx6KZ9i8ILO5XIoHB+Tg==
+react-error-overlay@^5.1.4:
+  version "5.1.6"
+  resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-5.1.6.tgz#0cd73407c5d141f9638ae1e0c63e7b2bf7e9929d"
+  integrity sha512-X1Y+0jR47ImDVr54Ab6V9eGk0Hnu7fVWGeHQSOXHf/C2pF9c6uy3gef8QUeuUiWlNb0i08InPSE5a/KJzNzw1Q==
 
 react-is@^16.7.0, react-is@^16.8.1:
-  version "16.8.3"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.3.tgz#4ad8b029c2a718fc0cfc746c8d4e1b7221e5387d"
-  integrity sha512-Y4rC1ZJmsxxkkPuMLwvKvlL1Zfpbcu+Bf4ZigkHup3v9EfdYhAlWAaVyA19olXq2o2mGn0w+dFKvk3pVVlYcIA==
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
+  integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
 
 react-onclickoutside@^6.7.1:
   version "6.8.0"
@@ -8074,9 +8221,9 @@ react-router@^4.3.1:
     warning "^4.0.1"
 
 react-scripts@^2.1.5:
-  version "2.1.5"
-  resolved "https://registry.yarnpkg.com/react-scripts/-/react-scripts-2.1.5.tgz#0740507db0a06d518c231caa1ef4e908bd8ebce5"
-  integrity sha512-NaDKSxBLlU/jmO3TjTChz0PnnGToaQn0R/y4l4/Uk1vZdrIUsKCGdOWV1z0SJoRg7bFgNKxh55yS0qMr8rFwCg==
+  version "2.1.8"
+  resolved "https://registry.yarnpkg.com/react-scripts/-/react-scripts-2.1.8.tgz#21195bb928b2c0462aa98b2d32edf7d034cff2a9"
+  integrity sha512-mDC8fYWCyuB9VROti8OCPdHE79UEchVVZmuS/yaIs47VkvZpgZqUvzghYBswZRchqnW0aARNY8xXrzoFRhhK7A==
   dependencies:
     "@babel/core" "7.2.2"
     "@svgr/webpack" "4.1.0"
@@ -8085,21 +8232,20 @@ react-scripts@^2.1.5:
     babel-jest "23.6.0"
     babel-loader "8.0.5"
     babel-plugin-named-asset-import "^0.3.1"
-    babel-preset-react-app "^7.0.1"
+    babel-preset-react-app "^7.0.2"
     bfj "6.1.1"
     case-sensitive-paths-webpack-plugin "2.2.0"
     css-loader "1.0.0"
     dotenv "6.0.0"
     dotenv-expand "4.2.0"
     eslint "5.12.0"
-    eslint-config-react-app "^3.0.7"
+    eslint-config-react-app "^3.0.8"
     eslint-loader "2.1.1"
     eslint-plugin-flowtype "2.50.1"
     eslint-plugin-import "2.14.0"
     eslint-plugin-jsx-a11y "6.1.2"
     eslint-plugin-react "7.12.4"
     file-loader "2.0.0"
-    fork-ts-checker-webpack-plugin-alt "0.4.14"
     fs-extra "7.0.1"
     html-webpack-plugin "4.0.0-alpha.2"
     identity-obj-proxy "3.0.0"
@@ -8114,8 +8260,8 @@ react-scripts@^2.1.5:
     postcss-loader "3.0.0"
     postcss-preset-env "6.5.0"
     postcss-safe-parser "4.0.1"
-    react-app-polyfill "^0.2.1"
-    react-dev-utils "^7.0.3"
+    react-app-polyfill "^0.2.2"
+    react-dev-utils "^8.0.0"
     resolve "1.10.0"
     sass-loader "7.1.0"
     style-loader "0.23.1"
@@ -8129,14 +8275,14 @@ react-scripts@^2.1.5:
     fsevents "1.2.4"
 
 react@^16.8.3:
-  version "16.8.3"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.8.3.tgz#c6f988a2ce895375de216edcfaedd6b9a76451d9"
-  integrity sha512-3UoSIsEq8yTJuSu0luO1QQWYbgGEILm+eJl2QN/VLDi7hL+EN18M3q3oVZwmVzzBJ3DkM7RMdRwBmZZ+b4IzSA==
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.8.6.tgz#ad6c3a9614fd3a4e9ef51117f54d888da01f2bbe"
+  integrity sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    scheduler "^0.13.3"
+    scheduler "^0.13.6"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"
@@ -8186,9 +8332,9 @@ read-pkg@^2.0.0:
     util-deprecate "~1.0.1"
 
 readable-stream@^3.0.6, readable-stream@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.1.1.tgz#ed6bbc6c5ba58b090039ff18ce670515795aeb06"
-  integrity sha512-DkN66hPyqDhnIQ6Jcsvx9bFjhw214O4poMBcIMgPVpQvNy9a0e0Uhg5SqySyDKAmUlwt8LonTBz1ezOnM8pUdA==
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.3.0.tgz#cb8011aad002eb717bf040291feba8569c986fb9"
+  integrity sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==
   dependencies:
     inherits "^2.0.3"
     string_decoder "^1.1.1"
@@ -8217,10 +8363,10 @@ recursive-readdir@2.2.2:
   dependencies:
     minimatch "3.0.4"
 
-regenerate-unicode-properties@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/regenerate-unicode-properties/-/regenerate-unicode-properties-7.0.0.tgz#107405afcc4a190ec5ed450ecaa00ed0cafa7a4c"
-  integrity sha512-s5NGghCE4itSlUS+0WUj88G6cfMVMmH8boTPNvABf8od+2dhT9WDlWu8n01raQAJZMOK8Ch6jSexaRO7swd6aw==
+regenerate-unicode-properties@^8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/regenerate-unicode-properties/-/regenerate-unicode-properties-8.0.2.tgz#7b38faa296252376d363558cfbda90c9ce709662"
+  integrity sha512-SbA/iNrBUf6Pv2zU8Ekv1Qbhv92yxL4hiDa2siuxs4KKn4oOoMDHXjAf7+Nz9qinUQ46B1LcWEi/PhJfPWpZWQ==
   dependencies:
     regenerate "^1.4.0"
 
@@ -8239,7 +8385,12 @@ regenerator-runtime@^0.12.0:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz#fa1a71544764c036f8c49b13a08b2594c9f8a0de"
   integrity sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==
 
-regenerator-transform@^0.13.3:
+regenerator-runtime@^0.13.2:
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz#32e59c9a6fb9b1a4aff09b4930ca2d4477343447"
+  integrity sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==
+
+regenerator-transform@^0.13.4:
   version "0.13.4"
   resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.13.4.tgz#18f6763cf1382c69c36df76c6ce122cc694284fb"
   integrity sha512-T0QMBjK3J0MtxjPmdIMXm72Wvj2Abb0Bd4HADdfijwMdoIsyQZ6fWC7kDFhk2YinBBEMZDL7Y7wh0J1sGx3S4A==
@@ -8262,9 +8413,9 @@ regex-not@^1.0.0, regex-not@^1.0.2:
     safe-regex "^1.1.0"
 
 regexp-tree@^0.1.0:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/regexp-tree/-/regexp-tree-0.1.5.tgz#7cd71fca17198d04b4176efd79713f2998009397"
-  integrity sha512-nUmxvfJyAODw+0B13hj8CFVAxhe7fDEAgJgaotBu3nnR+IgGgZq59YedJP5VYTlkEfqjuK6TuRpnymKdatLZfQ==
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/regexp-tree/-/regexp-tree-0.1.6.tgz#84900fa12fdf428a2ac25f04300382a7c0148479"
+  integrity sha512-LFrA98Dw/heXqDojz7qKFdygZmFoiVlvE1Zp7Cq2cvF+ZA+03Gmhy0k0PQlsC1jvHPiTUSs+pDHEuSWv6+6D7w==
 
 regexpp@^2.0.1:
   version "2.0.1"
@@ -8280,17 +8431,17 @@ regexpu-core@^1.0.0:
     regjsgen "^0.2.0"
     regjsparser "^0.1.4"
 
-regexpu-core@^4.1.3, regexpu-core@^4.2.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-4.4.0.tgz#8d43e0d1266883969720345e70c275ee0aec0d32"
-  integrity sha512-eDDWElbwwI3K0Lo6CqbQbA6FwgtCz4kYTarrri1okfkRLZAqstU+B3voZBCjg8Fl6iq0gXrJG6MvRgLthfvgOA==
+regexpu-core@^4.5.4:
+  version "4.5.4"
+  resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-4.5.4.tgz#080d9d02289aa87fe1667a4f5136bc98a6aebaae"
+  integrity sha512-BtizvGtFQKGPUcTy56o3nk1bGRp4SZOTYrDtGNlqCQufptV5IkkLN6Emw+yunAJjzf+C9FQFtvq7IoA3+oMYHQ==
   dependencies:
     regenerate "^1.4.0"
-    regenerate-unicode-properties "^7.0.0"
+    regenerate-unicode-properties "^8.0.2"
     regjsgen "^0.5.0"
     regjsparser "^0.6.0"
     unicode-match-property-ecmascript "^1.0.4"
-    unicode-match-property-value-ecmascript "^1.0.2"
+    unicode-match-property-value-ecmascript "^1.1.0"
 
 regjsgen@^0.2.0:
   version "0.2.0"
@@ -8462,10 +8613,17 @@ resolve@1.1.7:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
-resolve@1.10.0, resolve@^1.10.0, resolve@^1.3.2, resolve@^1.5.0, resolve@^1.6.0, resolve@^1.8.1, resolve@^1.9.0:
+resolve@1.10.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.10.0.tgz#3bdaaeaf45cc07f375656dfd2e54ed0810b101ba"
   integrity sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==
+  dependencies:
+    path-parse "^1.0.6"
+
+resolve@^1.10.0, resolve@^1.10.1, resolve@^1.3.2, resolve@^1.5.0, resolve@^1.6.0, resolve@^1.8.1, resolve@^1.9.0:
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.10.1.tgz#664842ac960795bbe758221cdccda61fb64b5f18"
+  integrity sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==
   dependencies:
     path-parse "^1.0.6"
 
@@ -8527,9 +8685,9 @@ run-queue@^1.0.0, run-queue@^1.0.3:
     aproba "^1.1.1"
 
 rxjs@^6.1.0, rxjs@^6.4.0:
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.4.0.tgz#f3bb0fe7bda7fb69deac0c16f17b50b0b8790504"
-  integrity sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.2.tgz#2e35ce815cd46d84d02a209fb4e5921e051dbec7"
+  integrity sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==
   dependencies:
     tslib "^1.9.0"
 
@@ -8583,10 +8741,10 @@ sax@^1.2.4, sax@~1.2.4:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
-scheduler@^0.13.3:
-  version "0.13.3"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.3.tgz#bed3c5850f62ea9c716a4d781f9daeb9b2a58896"
-  integrity sha512-UxN5QRYWtpR1egNWzJcVLk8jlegxAugswQc984lD3kU7NuobsO37/sRfbpTdBjtnD5TBNFA2Q2oLV5+UmPSmEQ==
+scheduler@^0.13.6:
+  version "0.13.6"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.6.tgz#466a4ec332467b31a91b9bf74e5347072e4cd889"
+  integrity sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
@@ -8642,9 +8800,14 @@ semantic-ui-react@^0.85.0:
     shallowequal "^1.1.0"
 
 "semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
-  integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.0.tgz#790a7cf6fea5459bac96110b29b60412dc8ff96b"
+  integrity sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==
+
+semver@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-6.0.0.tgz#05e359ee571e5ad7ed641a6eec1e547ba52dea65"
+  integrity sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ==
 
 send@0.16.2:
   version "0.16.2"
@@ -8666,9 +8829,9 @@ send@0.16.2:
     statuses "~1.4.0"
 
 serialize-javascript@^1.4.0:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.6.1.tgz#4d1f697ec49429a847ca6f442a2a755126c4d879"
-  integrity sha512-A5MOagrPFga4YaKQSWHryl7AXvbQkEqpw4NNYMTNYUNV51bA8ABHgYFpqKx+YFFrw59xMV1qGH1R4AgoNIVgCw==
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.7.0.tgz#d6e0dfb2a3832a8c94468e6eb1db97e55a192a65"
+  integrity sha512-ke8UG8ulpFOxO8f8gRYabHQe/ZntKlcig2Mp+8+URDP1D8vJZ0KUt7LYo07q25Z/+JVSgpr/cui9PIp5H6/+nA==
 
 serve-index@^1.7.2:
   version "1.9.1"
@@ -8896,10 +9059,10 @@ source-map-support@^0.4.15:
   dependencies:
     source-map "^0.5.6"
 
-source-map-support@^0.5.6, source-map-support@~0.5.9:
-  version "0.5.10"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.10.tgz#2214080bc9d51832511ee2bab96e3c2f9353120c"
-  integrity sha512-YfQ3tQFTK/yzlGJuX8pTwa4tifQj4QS2Mj7UegOu8jAz59MqIiMGPXxQhVQiIMNzayuUSF/jEuVnfFF5JqybmQ==
+source-map-support@^0.5.6, source-map-support@~0.5.10:
+  version "0.5.12"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.12.tgz#b4f3b10d51857a5af0138d3ce8003b201613d599"
+  integrity sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==
   dependencies:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
@@ -8920,11 +9083,9 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0, source-map@~0.6.1:
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
 space-separated-tokens@^1.0.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/space-separated-tokens/-/space-separated-tokens-1.1.2.tgz#e95ab9d19ae841e200808cd96bc7bd0adbbb3412"
-  integrity sha512-G3jprCEw+xFEs0ORweLmblJ3XLymGGr6hxZYTYZjIlvDti9vOBUjRQa1Rzjt012aRrocKstHwdNi+F7HguPsEA==
-  dependencies:
-    trim "0.0.1"
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/space-separated-tokens/-/space-separated-tokens-1.1.3.tgz#bc6500e116d13285a94b59b58c44c7f045fe6124"
+  integrity sha512-/M5RAdBuQlSDPNfA5ube+fkHbHyY08pMuADLmsAQURzo56w90r681oiOoz3o3ZQyWdSeNucpTFjL+Ggd5qui3w==
 
 spdx-correct@^3.0.0:
   version "3.1.0"
@@ -8948,9 +9109,9 @@ spdx-expression-parse@^3.0.0:
     spdx-license-ids "^3.0.0"
 
 spdx-license-ids@^3.0.0:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz#81c0ce8f21474756148bbb5f3bfc0f36bf15d76e"
-  integrity sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.4.tgz#75ecd1a88de8c184ef015eafb51b5b48bfd11bb1"
+  integrity sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA==
 
 spdy-transport@^3.0.0:
   version "3.0.0"
@@ -9009,7 +9170,7 @@ ssri@^6.0.1:
   dependencies:
     figgy-pudding "^3.5.1"
 
-stable@~0.1.6:
+stable@^0.1.8:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/stable/-/stable-0.1.8.tgz#836eb3c8382fe2936feaf544631017ce7d47a3cf"
   integrity sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==
@@ -9100,13 +9261,13 @@ string-width@^1.0.1:
     strip-ansi "^4.0.0"
 
 string-width@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-3.0.0.tgz#5a1690a57cc78211fffd9bf24bbe24d090604eb1"
-  integrity sha512-rr8CUxBbvOZDUvc5lNIJ+OC1nPVpz+Siw9VBtUjB9b6jZehZLFt0JMCZzShFHIsI8cbhm0EsNIfWJMFV3cu3Ew==
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-3.1.0.tgz#22767be21b62af1081574306f69ac51b62203961"
+  integrity sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==
   dependencies:
     emoji-regex "^7.0.1"
     is-fullwidth-code-point "^2.0.0"
-    strip-ansi "^5.0.0"
+    strip-ansi "^5.1.0"
 
 string_decoder@^1.0.0, string_decoder@^1.1.1:
   version "1.2.0"
@@ -9131,7 +9292,7 @@ stringify-object@^3.2.2:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-strip-ansi@5.0.0, strip-ansi@^5.0.0:
+strip-ansi@5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.0.0.tgz#f78f68b5d0866c20b2c9b8c61b5298508dc8756f"
   integrity sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==
@@ -9151,6 +9312,13 @@ strip-ansi@^4.0.0:
   integrity sha1-qEeQIusaw2iocTibY1JixQXuNo8=
   dependencies:
     ansi-regex "^3.0.0"
+
+strip-ansi@^5.0.0, strip-ansi@^5.1.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
+  integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
+  dependencies:
+    ansi-regex "^4.1.0"
 
 strip-bom@3.0.0, strip-bom@^3.0.0:
   version "3.0.0"
@@ -9225,23 +9393,23 @@ supports-color@^6.1.0:
   dependencies:
     has-flag "^3.0.0"
 
-svgo@^1.0.0, svgo@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/svgo/-/svgo-1.1.1.tgz#12384b03335bcecd85cfa5f4e3375fed671cb985"
-  integrity sha512-GBkJbnTuFpM4jFbiERHDWhZc/S/kpHToqmZag3aEBjPYK44JAN2QBjvrGIxLOoCyMZjuFQIfTO2eJd8uwLY/9g==
+svgo@^1.0.0, svgo@^1.2.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/svgo/-/svgo-1.2.2.tgz#0253d34eccf2aed4ad4f283e11ee75198f9d7316"
+  integrity sha512-rAfulcwp2D9jjdGu+0CuqlrAUin6bBWrpoqXWwKDZZZJfXcUXQSxLJOFJCQCSA0x0pP2U0TxSlJu2ROq5Bq6qA==
   dependencies:
-    coa "~2.0.1"
-    colors "~1.1.2"
+    chalk "^2.4.1"
+    coa "^2.0.2"
     css-select "^2.0.0"
-    css-select-base-adapter "~0.1.0"
+    css-select-base-adapter "^0.1.1"
     css-tree "1.0.0-alpha.28"
     css-url-regex "^1.1.0"
-    csso "^3.5.0"
-    js-yaml "^3.12.0"
+    csso "^3.5.1"
+    js-yaml "^3.13.1"
     mkdirp "~0.5.1"
-    object.values "^1.0.4"
+    object.values "^1.1.0"
     sax "~1.2.4"
-    stable "~0.1.6"
+    stable "^0.1.8"
     unquote "~1.1.1"
     util.promisify "~1.0.0"
 
@@ -9251,9 +9419,9 @@ symbol-tree@^3.2.2:
   integrity sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=
 
 table@^5.0.2:
-  version "5.2.3"
-  resolved "https://registry.yarnpkg.com/table/-/table-5.2.3.tgz#cde0cc6eb06751c009efab27e8c820ca5b67b7f2"
-  integrity sha512-N2RsDAMvDLvYwFcwbPyF3VmVSSkuF+G1e+8inhBLtHpvwXGw4QRPEZhihQNeEN0i1up6/f6ObCJXNdlRG3YVyQ==
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/table/-/table-5.3.3.tgz#eae560c90437331b74200e011487a33442bd28b4"
+  integrity sha512-3wUNCgdWX6PNpOe3amTTPWPuF6VGvgzjKCaO1snFj0z7Y3mUPWf5+zDtxUVGispJkDECPmR29wbzh6bVMOHbcw==
   dependencies:
     ajv "^6.9.1"
     lodash "^4.17.11"
@@ -9261,9 +9429,9 @@ table@^5.0.2:
     string-width "^3.0.0"
 
 tapable@^1.0.0, tapable@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.1.tgz#4d297923c5a72a42360de2ab52dadfaaec00018e"
-  integrity sha512-9I2ydhj8Z9veORCw5PRm4u9uebCn0mcCa6scWoNcbZ6dAtoo2618u9UUzxgmsCOreJpqDDuv61LvwofW7hLcBA==
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
+  integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
 
 tar@^4:
   version "4.4.8"
@@ -9278,7 +9446,7 @@ tar@^4:
     safe-buffer "^5.1.2"
     yallist "^3.0.2"
 
-terser-webpack-plugin@1.2.2, terser-webpack-plugin@^1.1.0:
+terser-webpack-plugin@1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-1.2.2.tgz#9bff3a891ad614855a7dde0d707f7db5a927e3d9"
   integrity sha512-1DMkTk286BzmfylAvLXwpJrI7dWa5BnFmscV/2dCr8+c56egFcbaeFAl7+sujAjdmpLam21XRdhA4oifLyiWWg==
@@ -9292,14 +9460,28 @@ terser-webpack-plugin@1.2.2, terser-webpack-plugin@^1.1.0:
     webpack-sources "^1.1.0"
     worker-farm "^1.5.2"
 
-terser@^3.16.1:
-  version "3.16.1"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-3.16.1.tgz#5b0dd4fa1ffd0b0b43c2493b2c364fd179160493"
-  integrity sha512-JDJjgleBROeek2iBcSNzOHLKsB/MdDf+E/BOAJ0Tk9r7p9/fVobfv7LMJ/g/k3v9SXdmjZnIlFd5nfn/Rt0Xow==
+terser-webpack-plugin@^1.1.0:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-1.2.3.tgz#3f98bc902fac3e5d0de730869f50668561262ec8"
+  integrity sha512-GOK7q85oAb/5kE12fMuLdn2btOS9OBZn4VsecpHDywoUC/jLhSAKOiYo0ezx7ss2EXPMzyEWFoE0s1WLE+4+oA==
   dependencies:
-    commander "~2.17.1"
+    cacache "^11.0.2"
+    find-cache-dir "^2.0.0"
+    schema-utils "^1.0.0"
+    serialize-javascript "^1.4.0"
+    source-map "^0.6.1"
+    terser "^3.16.1"
+    webpack-sources "^1.1.0"
+    worker-farm "^1.5.2"
+
+terser@^3.16.1:
+  version "3.17.0"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-3.17.0.tgz#f88ffbeda0deb5637f9d24b0da66f4e15ab10cb2"
+  integrity sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==
+  dependencies:
+    commander "^2.19.0"
     source-map "~0.6.1"
-    source-map-support "~0.5.9"
+    source-map-support "~0.5.10"
 
 test-exclude@^4.2.1:
   version "4.2.3"
@@ -9351,6 +9533,16 @@ timsort@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
   integrity sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=
+
+tiny-invariant@^1.0.2:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.0.4.tgz#346b5415fd93cb696b0c4e8a96697ff590f92463"
+  integrity sha512-lMhRd/djQJ3MoaHEBrw8e2/uM4rs9YMNk0iOr8rHQ0QdbM7D4l0gFl3szKdeixrlyfm9Zqi4dxHCM2qVG8ND5g==
+
+tiny-warning@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.2.tgz#1dfae771ee1a04396bdfde27a3adcebc6b648b28"
+  integrity sha512-rru86D9CpQRLvsFG5XFdy0KdLAvjdQDyZCsRcuu60WtzFylDM3eAWSxEVz5kzL2Gp544XiUvPbVKtOA/txLi9Q==
 
 tmp@^0.0.33:
   version "0.0.33"
@@ -9439,11 +9631,6 @@ trim-right@^1.0.1:
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
   integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
 
-trim@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
-  integrity sha1-WFhUf2spB1fulczMZm+1AITEYN0=
-
 trough@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.3.tgz#e29bd1614c6458d44869fc28b255ab7857ef7c24"
@@ -9455,9 +9642,9 @@ tryer@^1.0.0:
   integrity sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==
 
 ts-pnp@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.0.1.tgz#fde74a6371676a167abaeda1ffc0fdb423520098"
-  integrity sha512-Zzg9XH0anaqhNSlDRibNC8Kp+B9KNM0uRIpLpGkGyrgRIttA7zZBhotTSEoEyuDrz3QW2LGtu2dxuk34HzIGnQ==
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.1.2.tgz#be8e4bfce5d00f0f58e0666a82260c34a57af552"
+  integrity sha512-f5Knjh7XCyRIzoC/z1Su1yLLRrPrFCgtUAh/9fCSP6NKbATwpOL1+idQVXQokK9GRFURn/jYPGPfegIctwunoA==
 
 tslib@^1.9.0:
   version "1.9.3"
@@ -9489,12 +9676,12 @@ type-check@~0.3.2:
     prelude-ls "~1.1.2"
 
 type-is@~1.6.16:
-  version "1.6.16"
-  resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.16.tgz#f89ce341541c672b25ee7ae3c73dee3b2be50194"
-  integrity sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==
+  version "1.6.18"
+  resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.18.tgz#4e552cd05df09467dcbc4ef739de89f2cf37c131"
+  integrity sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==
   dependencies:
     media-typer "0.3.0"
-    mime-types "~2.1.18"
+    mime-types "~2.1.24"
 
 typed-styles@^0.0.7:
   version "0.0.7"
@@ -9511,12 +9698,20 @@ ua-parser-js@^0.7.18:
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.19.tgz#94151be4c0a7fb1d001af7022fdaca4642659e4b"
   integrity sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ==
 
-uglify-js@3.4.x, uglify-js@^3.1.4:
-  version "3.4.9"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.4.9.tgz#af02f180c1207d76432e473ed24a28f4a782bae3"
-  integrity sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==
+uglify-js@3.4.x:
+  version "3.4.10"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.4.10.tgz#9ad9563d8eb3acdfb8d38597d2af1d815f6a755f"
+  integrity sha512-Y2VsbPVs0FIshJztycsO2SfPk7/KAF/T72qzv9u5EpQ4kB2hQoHlhNQTsNyy6ul7lQtqJN/AoWeS23OzEiEFxw==
   dependencies:
-    commander "~2.17.1"
+    commander "~2.19.0"
+    source-map "~0.6.1"
+
+uglify-js@^3.1.4:
+  version "3.5.12"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.5.12.tgz#6b759cabc08c3e91fe82323d6387019f0c5864cd"
+  integrity sha512-KeQesOpPiZNgVwJj8Ge3P4JYbQHUdZzpx6Fahy6eKAYRSV4zhVmLXoC+JtOeYxcHCHTve8RG1ZGdTvpeOUM26Q==
+  dependencies:
+    commander "~2.20.0"
     source-map "~0.6.1"
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
@@ -9532,17 +9727,17 @@ unicode-match-property-ecmascript@^1.0.4:
     unicode-canonical-property-names-ecmascript "^1.0.4"
     unicode-property-aliases-ecmascript "^1.0.4"
 
-unicode-match-property-value-ecmascript@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.0.2.tgz#9f1dc76926d6ccf452310564fd834ace059663d4"
-  integrity sha512-Rx7yODZC1L/T8XKo/2kNzVAQaRE88AaMvI1EF/Xnj3GW2wzN6fop9DDWuFAKUVFH7vozkz26DzP0qyWLKLIVPQ==
+unicode-match-property-value-ecmascript@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.1.0.tgz#5b4b426e08d13a80365e0d657ac7a6c1ec46a277"
+  integrity sha512-hDTHvaBk3RmFzvSl0UVrUmC3PuW9wKVnpoUDYH0JDkSIovzw+J5viQmeYHxVSBptubnr7PbH2e0fnpDRQnQl5g==
 
 unicode-property-aliases-ecmascript@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.4.tgz#5a533f31b4317ea76f17d807fa0d116546111dd0"
-  integrity sha512-2WSLa6OdYd2ng8oqiGIWnJqyFArvhn+5vgx5GTxMbUYjCYKUcuKS62YLFF0R/BDGlB1yzXjQOLtPAfHsgirEpg==
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz#a9cc6cc7ce63a0a3023fc99e341b94431d405a57"
+  integrity sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw==
 
-unified@^7.0.2:
+unified@^7.1.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/unified/-/unified-7.1.0.tgz#5032f1c1ee3364bd09da12e27fdd4a7553c7be13"
   integrity sha512-lbk82UOIGuCEsZhPj8rNAkXSDXd6p0QLzIuSsCdxrqnqU56St4eyOB+AlXsVgVeRmetPTYydIuvFfpDIed8mqw==
@@ -9595,6 +9790,13 @@ unist-util-stringify-position@^1.0.0, unist-util-stringify-position@^1.1.1:
   resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz#3f37fcf351279dcbca7480ab5889bb8a832ee1c6"
   integrity sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ==
 
+unist-util-stringify-position@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-2.0.0.tgz#4c452c0dbcbc509f7bcd366e9a8afd646f9d51ae"
+  integrity sha512-Uz5negUTrf9zm2ZT2Z9kdOL7Mr7FJLyq3ByqagUi7QZRVK1HnspVazvSqwHt73jj7APHtpuJ4K110Jm8O6/elw==
+  dependencies:
+    "@types/unist" "^2.0.2"
+
 universalify@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
@@ -9618,10 +9820,10 @@ unset-value@^1.0.0:
     has-value "^0.3.1"
     isobject "^3.0.0"
 
-upath@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/upath/-/upath-1.1.0.tgz#35256597e46a581db4793d0ce47fa9aebfc9fabd"
-  integrity sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw==
+upath@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/upath/-/upath-1.1.2.tgz#3db658600edaeeccbe6db5e684d67ee8c2acd068"
+  integrity sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==
 
 upper-case@^1.1.1:
   version "1.1.3"
@@ -9650,11 +9852,11 @@ url-loader@1.1.2:
     schema-utils "^1.0.0"
 
 url-parse@^1.4.3:
-  version "1.4.4"
-  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.4.4.tgz#cac1556e95faa0303691fec5cf9d5a1bc34648f8"
-  integrity sha512-/92DTTorg4JjktLNLe6GPS2/RvAd/RGr6LuktmWSMLEOa6rjnlrFXNgSbSmkNvCoL2T028A0a1JaJLzRMlFoHg==
+  version "1.4.7"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.4.7.tgz#a8a83535e8c00a316e403a5db4ac1b9b853ae278"
+  integrity sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==
   dependencies:
-    querystringify "^2.0.0"
+    querystringify "^2.1.1"
     requires-port "^1.0.0"
 
 url@^0.11.0:
@@ -9731,9 +9933,9 @@ vary@~1.1.2:
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
 
 vendors@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/vendors/-/vendors-1.0.2.tgz#7fcb5eef9f5623b156bcea89ec37d63676f21801"
-  integrity sha512-w/hry/368nO21AN9QljsaIhb9ZiZtZARoVH5f3CsFbawdLdayCgKRPup7CggujvySMxx0I91NOyxdVENohprLQ==
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/vendors/-/vendors-1.0.3.tgz#a6467781abd366217c050f8202e7e50cc9eef8c0"
+  integrity sha512-fOi47nsJP5Wqefa43kyWSg80qF+Q3XA6MUkgi7Hp1HQaKDQW4cQrK2D0P7mmbFtsV1N89am55Yru/nyEwRubcw==
 
 verror@1.10.0:
   version "1.10.0"
@@ -9751,7 +9953,15 @@ vfile-message@^1.0.0:
   dependencies:
     unist-util-stringify-position "^1.1.1"
 
-vfile@^3.0.0, vfile@^3.0.1:
+vfile-message@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-2.0.0.tgz#750bbb86fe545988a67e899b329bbcabb73edef6"
+  integrity sha512-YS6qg6UpBfIeiO+6XlhPOuJaoLvt1Y9g2cmlwqhBOOU0XRV8j5RLeoz72t6PWLvNXq3EBG1fQ05wNPrUoz0deQ==
+  dependencies:
+    "@types/unist" "^2.0.2"
+    unist-util-stringify-position "^1.1.1"
+
+vfile@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/vfile/-/vfile-3.0.1.tgz#47331d2abe3282424f4a4bb6acd20a44c4121803"
   integrity sha512-y7Y3gH9BsUSdD4KzHsuMaCzRjglXN0W2EcMf0gpvu6+SbsGhMje7xDc8AEoeXy6mIwCKMI6BkjMsRjzQbhMEjQ==
@@ -9760,6 +9970,17 @@ vfile@^3.0.0, vfile@^3.0.1:
     replace-ext "1.0.0"
     unist-util-stringify-position "^1.0.0"
     vfile-message "^1.0.0"
+
+vfile@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/vfile/-/vfile-4.0.0.tgz#ebf3b48af9fcde524d5e08d5f75812058a5f78ad"
+  integrity sha512-WMNeHy5djSl895BqE86D7WqA0Ie5fAIeGCa7V1EqiXyJg5LaGch2SUaZueok5abYQGH6mXEAsZ45jkoILIOlyA==
+  dependencies:
+    "@types/unist" "^2.0.2"
+    is-buffer "^2.0.0"
+    replace-ext "1.0.0"
+    unist-util-stringify-position "^2.0.0"
+    vfile-message "^2.0.0"
 
 vm-browserify@0.0.4:
   version "0.0.4"
@@ -9781,13 +10002,6 @@ walker@~1.0.5:
   integrity sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=
   dependencies:
     makeerror "1.0.x"
-
-warning@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/warning/-/warning-3.0.0.tgz#32e5377cb572de4ab04753bdf8821c01ed605b7c"
-  integrity sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=
-  dependencies:
-    loose-envify "^1.0.0"
 
 warning@^4.0.1, warning@^4.0.2:
   version "4.0.3"
@@ -9821,9 +10035,9 @@ wbuf@^1.1.0, wbuf@^1.7.3:
     minimalistic-assert "^1.0.0"
 
 web-namespaces@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/web-namespaces/-/web-namespaces-1.1.2.tgz#c8dc267ab639505276bae19e129dbd6ae72b22b4"
-  integrity sha512-II+n2ms4mPxK+RnIxRPOw3zwF2jRscdJIUE9BfkKHm4FYEg9+biIoTMnaZF5MpemE3T+VhMLrhbyD4ilkPCSbg==
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/web-namespaces/-/web-namespaces-1.1.3.tgz#9bbf5c99ff0908d2da031f1d732492a96571a83f"
+  integrity sha512-r8sAtNmgR0WKOKOxzuSgk09JsHlpKlB+uHi937qypOu3PZ17UxPrierFKDye/uNHjNTTEshu5PId8rojIPj/tA==
 
 webidl-conversions@^4.0.2:
   version "4.0.2"
@@ -10136,9 +10350,9 @@ workbox-webpack-plugin@3.6.3:
     workbox-build "^3.6.3"
 
 worker-farm@^1.5.2:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/worker-farm/-/worker-farm-1.6.0.tgz#aecc405976fab5a95526180846f0dba288f3a4a0"
-  integrity sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/worker-farm/-/worker-farm-1.7.0.tgz#26a94c5391bbca926152002f69b84a4bf772e5a8"
+  integrity sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==
   dependencies:
     errno "~0.1.7"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -696,6 +696,11 @@
     exenv "^1.2.2"
     prop-types "^15.6.2"
 
+"@types/normalize-package-data@^2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
+  integrity sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==
+
 JSONStream@^1.0.4, JSONStream@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.5.tgz#3208c1f08d3a4d99261ab64f92302bc15e111ca0"
@@ -819,6 +824,14 @@ array-ify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/array-ify/-/array-ify-1.0.0.tgz#9e528762b4a9066ad163a6962a364418e9626ece"
   integrity sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=
+
+array-includes@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.0.3.tgz#184b48f62d92d7452bb31b323165c7f8bd02266d"
+  integrity sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.7.0"
 
 array-map@~0.0.0:
   version "0.0.0"
@@ -1108,6 +1121,11 @@ ci-info@^1.5.0:
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.6.0.tgz#2ca20dbb9ceb32d4524a683303313f0304b1e497"
   integrity sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==
 
+ci-info@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
+  integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
+
 class-utils@^0.3.5:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/class-utils/-/class-utils-0.3.6.tgz#f93369ae8b9a7ce02fd41faad0ca83033190c463"
@@ -1376,7 +1394,7 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
-cosmiconfig@^5.1.0:
+cosmiconfig@^5.1.0, cosmiconfig@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.2.0.tgz#45038e4d28a7fe787203aede9c25bca4a08b12c8"
   integrity sha512-nxt+Nfc3JAqf4WIWd0jXLjTJZmsPLrA9DDc4nRw2KFJQJK7DNooqSXrNI7tzLG50CF8axczly5UV929tBmh/7g==
@@ -1559,6 +1577,13 @@ dir-glob@2.0.0:
     arrify "^1.0.1"
     path-type "^3.0.0"
 
+doctrine@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
+  integrity sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==
+  dependencies:
+    esutils "^2.0.2"
+
 dot-prop@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-3.0.0.tgz#1b708af094a49c9a0e7dbcad790aba539dac1177"
@@ -1622,7 +1647,7 @@ error-ex@^1.2.0, error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
-es-abstract@^1.4.3:
+es-abstract@^1.11.0, es-abstract@^1.4.3, es-abstract@^1.7.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.13.0.tgz#ac86145fdd5099d8dd49558ccba2eaf9b88e24e9"
   integrity sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==
@@ -1660,10 +1685,28 @@ escape-string-regexp@^1.0.5:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
+eslint-plugin-react@^7.13.0:
+  version "7.13.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.13.0.tgz#bc13fd7101de67996ea51b33873cd9dc2b7e5758"
+  integrity sha512-uA5LrHylu8lW/eAH3bEQe9YdzpPaFd9yAJTwTi/i/BKTD7j6aQMKVAdGM/ML72zD6womuSK7EiGtMKuK06lWjQ==
+  dependencies:
+    array-includes "^3.0.3"
+    doctrine "^2.1.0"
+    has "^1.0.3"
+    jsx-ast-utils "^2.1.0"
+    object.fromentries "^2.0.0"
+    prop-types "^15.7.2"
+    resolve "^1.10.1"
+
 esprima@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
+
+esutils@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
+  integrity sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=
 
 execa@^1.0.0:
   version "1.0.0"
@@ -1962,6 +2005,11 @@ get-stdin@^4.0.1:
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
   integrity sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=
 
+get-stdin@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-7.0.0.tgz#8d5de98f15171a125c5e516643c7a6d0ea8a96f6"
+  integrity sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==
+
 get-stream@^4.0.0, get-stream@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-4.1.0.tgz#c1b255575f3dc21d59bfc79cd3d2b46b1c3a54b5"
@@ -2192,6 +2240,22 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
+husky@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-2.2.0.tgz#4dda4370ba0f145b6594be4a4e4e4d4c82a6f2d5"
+  integrity sha512-lG33E7zq6v//H/DQIojPEi1ZL9ebPFt3MxUMD8MR0lrS2ljEPiuUUxlziKIs/o9EafF0chL7bAtLQkcPvXmdnA==
+  dependencies:
+    cosmiconfig "^5.2.0"
+    execa "^1.0.0"
+    find-up "^3.0.0"
+    get-stdin "^7.0.0"
+    is-ci "^2.0.0"
+    pkg-dir "^4.1.0"
+    please-upgrade-node "^3.1.1"
+    read-pkg "^5.0.0"
+    run-node "^1.0.0"
+    slash "^2.0.0"
+
 iconv-lite@^0.4.24, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
@@ -2345,6 +2409,13 @@ is-ci@^1.0.10:
   integrity sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==
   dependencies:
     ci-info "^1.5.0"
+
+is-ci@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-2.0.0.tgz#6bc6334181810e04b5c22b3d589fdca55026404c"
+  integrity sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==
+  dependencies:
+    ci-info "^2.0.0"
 
 is-data-descriptor@^0.1.4:
   version "0.1.4"
@@ -2618,6 +2689,13 @@ jsprim@^1.2.2:
     extsprintf "1.3.0"
     json-schema "0.2.3"
     verror "1.10.0"
+
+jsx-ast-utils@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-2.1.0.tgz#0ee4e2c971fb9601c67b5641b71be80faecf0b36"
+  integrity sha512-yDGDG2DS4JcqhA6blsuYbtsT09xL8AoLuUR2Gb5exrw7UEM19sBcOTq+YBBhrNbl0PUC4R4LnFu+dHg2HKeVvA==
+  dependencies:
+    array-includes "^3.0.3"
 
 keyboard-key@^1.0.4:
   version "1.0.4"
@@ -3168,7 +3246,7 @@ node-gyp@^3.8.0:
   dependencies:
     abbrev "1"
 
-normalize-package-data@^2.0.0, normalize-package-data@^2.3.0, normalize-package-data@^2.3.2, normalize-package-data@^2.3.4, normalize-package-data@^2.3.5, normalize-package-data@^2.4.0:
+normalize-package-data@^2.0.0, normalize-package-data@^2.3.0, normalize-package-data@^2.3.2, normalize-package-data@^2.3.4, normalize-package-data@^2.3.5, normalize-package-data@^2.4.0, normalize-package-data@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
   integrity sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==
@@ -3313,6 +3391,16 @@ object-visit@^1.0.0:
   integrity sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=
   dependencies:
     isobject "^3.0.0"
+
+object.fromentries@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/object.fromentries/-/object.fromentries-2.0.0.tgz#49a543d92151f8277b3ac9600f1e930b189d30ab"
+  integrity sha512-9iLiI6H083uiqUuvzyY6qrlmc/Gz8hLQFOcb/Ri/0xXFkSNS3ctV+CbE6yM2+AnkYfOB3dGjdzC0wrMLIhQICA==
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.11.0"
+    function-bind "^1.1.1"
+    has "^1.0.1"
 
 object.pick@^1.3.0:
   version "1.3.0"
@@ -3707,6 +3795,20 @@ pkg-dir@^2.0.0:
   dependencies:
     find-up "^2.1.0"
 
+pkg-dir@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-4.1.0.tgz#aaeb91c0d3b9c4f74a44ad849f4de34781ae01de"
+  integrity sha512-55k9QN4saZ8q518lE6EFgYiu95u3BWkSajCifhdQjvLvmr8IpnRbhI+UGpWJQfa0KzDguHeeWT1ccO1PmkOi3A==
+  dependencies:
+    find-up "^3.0.0"
+
+please-upgrade-node@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.1.1.tgz#ed320051dfcc5024fae696712c8288993595e8ac"
+  integrity sha512-KY1uHnQ2NlQHqIJQpnh/i54rKkuxCEBx+voJIS/Mvb+L2iYd2NMotwduhKTMjfC1uKoX3VXOxLjIYG66dfJTVQ==
+  dependencies:
+    semver-compare "^1.0.0"
+
 posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
@@ -3737,7 +3839,7 @@ promzard@^0.3.0:
   dependencies:
     read "1"
 
-prop-types@^15.6.2:
+prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -3897,6 +3999,16 @@ read-pkg@^3.0.0:
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
 
+read-pkg@^5.0.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-5.1.1.tgz#5cf234dde7a405c90c88a519ab73c467e9cb83f5"
+  integrity sha512-dFcTLQi6BZ+aFUaICg7er+/usEoqFdQxiEBsEMNGoipenihtxxtdrQuBXvyANCEI8VuUIVYFgeHGx9sLLvim4w==
+  dependencies:
+    "@types/normalize-package-data" "^2.4.0"
+    normalize-package-data "^2.5.0"
+    parse-json "^4.0.0"
+    type-fest "^0.4.1"
+
 read@1, read@~1.0.1:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/read/-/read-1.0.7.tgz#b3da19bd052431a97671d44a42634adf710b40c4"
@@ -4040,7 +4152,7 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.10.0:
+resolve@^1.10.0, resolve@^1.10.1:
   version "1.10.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.10.1.tgz#664842ac960795bbe758221cdccda61fb64b5f18"
   integrity sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==
@@ -4078,6 +4190,11 @@ run-async@^2.2.0:
   integrity sha1-A3GrSuC91yDUFm19/aZP96RFpsA=
   dependencies:
     is-promise "^2.1.0"
+
+run-node@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/run-node/-/run-node-1.0.0.tgz#46b50b946a2aa2d4947ae1d886e9856fd9cabe5e"
+  integrity sha512-kc120TBlQ3mih1LSzdAJXo4xn/GWS2ec0l3S+syHDXP9uRr0JAT8Qd3mdMuyjqCzeZktgP3try92cEgf9Nks8A==
 
 run-queue@^1.0.0, run-queue@^1.0.3:
   version "1.0.3"
@@ -4123,6 +4240,11 @@ semantic-ui-react@^0.86.0:
     prop-types "^15.6.2"
     react-is "^16.7.0"
     shallowequal "^1.1.0"
+
+semver-compare@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
+  integrity sha1-De4hahyUGrN+nvsXiPavxf9VN/w=
 
 "semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
   version "5.7.0"
@@ -4195,6 +4317,11 @@ slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
   integrity sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=
+
+slash@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
+  integrity sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==
 
 slide@^1.1.6:
   version "1.1.6"
@@ -4619,6 +4746,11 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
   integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
+
+type-fest@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.4.1.tgz#8bdf77743385d8a4f13ba95f610f5ccd68c728f8"
+  integrity sha512-IwzA/LSfD2vC1/YDYMv/zHP4rDF1usCwllsDpbolT3D4fUepIO7f9K70jjmUewU/LmGUKJcwcVtDCpnKk4BPMw==
 
 typedarray@^0.0.6:
   version "0.0.6"


### PR DESCRIPTION
Description: set very basic eslint rules and run with --fix on precommit. Rules are very permissive - mostly just fixes indentation, semicolons, and quotes. We may want to add some stricter rules like not allowing console statements and enforcing prop-types when we're about ready for go-live - maybe as part of the
post-freeze polish. Also added yarn audit --fix to the precommit to catch npm package vulnerabilities.

NOTE - ironically, while this change is to prevent us from having to see huge, mostly meaningless diffs on future pull requests, the diff will be massive here, as it involves running eslint on every source file for the first time. The most relevant changes will be in the two newly added .eslintrc files, and in the top-level package.json, the rest should be mostly just fixing indentation (including changing tabs to spaces), stripping semicolons, and changing double quotes to single.