### PR TITLE
feat(build): resolve s3 bucket name via process.env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ lerna-debug.log
 npm-debug.log
 packages/ui/build/
 packages/api/.env
+server_config/bp_api.service
+*.tfstate
+*.tfstate.backup
+.terraform/

--- a/packages/api/.env.example
+++ b/packages/api/.env.example
@@ -1,5 +1,6 @@
 UI_SERVER=http://localhost:3000
 S3_BUCKET=http://localhost:9001
+S3_BUCKET_NAME=beautiful-portland-carousel-photos
 S3_ACCESS_KEY=b@dpass
 S3_SECRET_ACCESS_KEY=r3alb@dpass
 MONGODB_URL=mongodb+srv://admin:admin@beautiful-portland-db-w9xpb.mongodb.net/test

--- a/packages/api/admin.js
+++ b/packages/api/admin.js
@@ -233,7 +233,7 @@ addPhotos = function(req, res) {
   })
   let file = req.body.filesToAdd
   let buf = new Buffer(file.fileData.replace(/^data:image\/\w+;base64,/, ''), 'base64')
-  const bucket = 'beautiful-portland-carousel-photos'
+  const bucket = process.env.S3_BUCKET_NAME
   if (req.body.isFrontPage === true) {
     file.fileName = 'frontPage/' + file.fileName
   }
@@ -259,7 +259,7 @@ removeImageFromBucket = function(req, res) {
     accessKeyId: process.env.S3_ACCESS_KEY,
     secretAccessKey: process.env.S3_SECRET_ACCESS_KEY
   })
-  const bucket = 'beautiful-portland-carousel-photos'
+  const bucket = process.env.S3_BUCKET_NAME
   // Get presigned url and parse for file name
   const urls = req.body.urlsToRemove
   let files = []
@@ -309,7 +309,7 @@ removeImagesFromFrontPage = function(req, res) {
     accessKeyId: process.env.S3_ACCESS_KEY,
     secretAccessKey: process.env.S3_SECRET_ACCESS_KEY
   })
-  const bucket = 'beautiful-portland-carousel-photos'
+  const bucket = process.env.S3_BUCKET_NAME
   // Get presigned url and parse for file name
   const urls = req.body.urlsToRemove
   urls.forEach((url) => {
@@ -358,7 +358,7 @@ addImageIntoStories = function(req, res) {
     accessKeyId: process.env.S3_ACCESS_KEY,
     secretAccessKey: process.env.S3_SECRET_ACCESS_KEY
   })
-  const bucket = 'beautiful-portland-carousel-photos'
+  const bucket = process.env.S3_BUCKET_NAME
   let file = req.body.fileToAdd
   let buf = new Buffer(file.fileData.replace(/^data:image\/\w+;base64,/, ''), 'base64')
   file.fileName = 'storyPhotos/' + file.fileName
@@ -382,7 +382,7 @@ removeImageFromStories = function(req, res) {
     accessKeyId: process.env.S3_ACCESS_KEY,
     secretAccessKey: process.env.S3_SECRET_ACCESS_KEY
   })
-  const bucket = 'beautiful-portland-carousel-photos'
+  const bucket = process.env.S3_BUCKET_NAME
   let fileToDelete = 'storyPhotos/' + req.body.fileToRemove
   console.log(fileToDelete)
   const params = {
@@ -420,7 +420,7 @@ addFromUploaded = function(req, res) {
     accessKeyId: process.env.S3_ACCESS_KEY,
     secretAccessKey: process.env.S3_SECRET_ACCESS_KEY
   })
-  const bucket = 'beautiful-portland-carousel-photos'
+  const bucket = process.env.S3_BUCKET_NAME
   // Get presigned url and parse for file name
   const urls = req.body.urlsToRemove
   urls.forEach((url) => {
@@ -1004,4 +1004,3 @@ module.exports.addCalendarFAQ = addCalendarFAQ
 module.exports.editCalendarFAQ = editCalendarFAQ
 module.exports.deleteCalendarFAQ = deleteCalendarFAQ
 module.exports.emergencyRefresh = emergencyRefresh
-

--- a/packages/api/visitor.js
+++ b/packages/api/visitor.js
@@ -7,7 +7,7 @@ getImageForStory = function(req, res) {
     accessKeyId: process.env.S3_ACCESS_KEY,
     secretAccessKey: process.env.S3_SECRET_ACCESS_KEY
   })
-  const bucket = 'beautiful-portland-carousel-photos'
+  const bucket = process.env.S3_BUCKET_NAME
   let key = 'storyPhotos/' + req.query.fileName
   try {
     let url = s3.getSignedUrl('getObject', {Bucket: bucket, Key: key})
@@ -35,7 +35,7 @@ homeImages = function(req, res) {
     accessKeyId: process.env.S3_ACCESS_KEY,
     secretAccessKey: process.env.S3_SECRET_ACCESS_KEY
   })
-  const bucket = 'beautiful-portland-carousel-photos'
+  const bucket = process.env.S3_BUCKET_NAME
   let imageUrls = []
   // Checks for if on front page (or editing front page images)
   let isFront = req.query.isFrontPage
@@ -238,7 +238,7 @@ displayStory = function(req, res) {
       accessKeyId: process.env.S3_ACCESS_KEY,
       secretAccessKey: process.env.S3_SECRET_ACCESS_KEY
     })
-    const bucket = 'beautiful-portland-carousel-photos'
+    const bucket = process.env.S3_BUCKET_NAME
     let response_data = []
     docs.map((pubStory) => {
       var publishObj = new Object()
@@ -311,7 +311,7 @@ getOneStory = function(req, res) {
       accessKeyId: process.env.S3_ACCESS_KEY,
       secretAccessKey: process.env.S3_SECRET_ACCESS_KEY
     })
-    const bucket = 'beautiful-portland-carousel-photos'
+    const bucket = process.env.S3_BUCKET_NAME
     let response_data = []
     docs.map((pubStory) => {
       var publishObj = new Object()


### PR DESCRIPTION
Description: S3 bucket names are global, which means that if we want to keep a separate test environment after prod goes up, we need to stop using a hardcoded value for the s3 bucket name. This change
moves responsibility for the bucket name to the .env file.