### PR TITLE
fix(admin): make event template refresh work again after master rename

### DIFF
--- a/packages/api/admin.js
+++ b/packages/api/admin.js
@@ -797,7 +797,7 @@ emergencyRefresh = function(req, res) {
   let client = this.dbClient
   let response_data = []
   collection = client.db('events-form').collection('events')
-  collection.find({date: 'MASTER'}, {projection:{ _id: 0}}).toArray((err, docs) => {
+  collection.find({date: 'MASTER2'}, {projection:{ _id: 0}}).toArray((err, docs) => {
     if(err) {
       console.log(err, 'Error trying to get info from master template')
       res.send({


### PR DESCRIPTION
Description: the name of the document being used as the master event template was previously changed from MASTER2 to MASTER, for emergencyRefresh it was necessary to also change the backup template name from MASTER to MASTER2, this catches that.